### PR TITLE
fix Estonian number regex

### DIFF
--- a/lib/phone/ee.ex
+++ b/lib/phone/ee.ex
@@ -1,6 +1,6 @@
 defmodule Phone.EE do
   use Helper.Country
-  field :regex, ~r/^(372)()(.{7})/
+  field :regex, ~r/^(372)()(.{7,8})/
   field :country, "Estonia"
   field :a2, "EE"
   field :a3, "EST"


### PR DESCRIPTION
Estonian numbers can also have 8 digits

https://en.wikipedia.org/wiki/Telephone_numbers_in_Estonia