### PR TITLE
numbers in Bosnia and Herzegovina can also be 1 digit longer

### DIFF
--- a/lib/phone/ba.ex
+++ b/lib/phone/ba.ex
@@ -1,6 +1,6 @@
 defmodule Phone.BA do
   use Helper.Country
-  field :regex, ~r/^(387)(..)(.{5})/
+  field :regex, ~r/^(387)(..)(.{5,6})/
   field :country, "Bosnia and Herzegovina"
   field :a2, "BA"
   field :a3, "BIH"


### PR DESCRIPTION
Bosnian phone numbers can have one more digit.