### PR TITLE
10 figures for Italian numbers.

### DIFF
--- a/lib/phone/it.ex
+++ b/lib/phone/it.ex
@@ -1,6 +1,6 @@
 defmodule Phone.IT do
   use Helper.Country
-  field :regex, ~r/^(39)()(.{9})/
+  field :regex, ~r/^(39)()(.{9,10})/
   field :country, "Italy"
   field :a2, "IT"
   field :a3, "ITA"


### PR DESCRIPTION
For Italian, a phone number (especially for mobiles) can have 10 figures (without international code).
Eg: “+39 347 11 22 333” is legal