### PR TITLE
Fixes Ontario’s 519 area code

### DIFF
--- a/lib/phone/nanp/ca/on.ex
+++ b/lib/phone/nanp/ca/on.ex
@@ -1,6 +1,6 @@
 defmodule Phone.NANP.CA.ON do
   use Helper.Area
-  field :regex, ~r/^(1)(226|249|289|343|365|416|437|529|613|647|705|807|905)([2-9].{6})$/
+  field :regex, ~r/^(1)(226|249|289|343|365|416|437|519|613|647|705|807|905)([2-9].{6})$/
   field :area_name, "Ontario"
   field :area_type, "province"
   field :area_abbreviation, "ON"


### PR DESCRIPTION
The 529 area code is non-existent. It should be 519 instead.

https://en.wikipedia.org/wiki/List_of_North_American_Numbering_Plan_area_codes