### PR TITLE
WIP: Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /_build
+/bench/snapshots
 /cover
 /doc
 /docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,23 +27,21 @@ Required fields for an country module:
   * a2, two letter code for that country.
   * a3, three letter code for that country.
   * modules, list of area modules for that country.
-  * match, a macro to say if that country should match against regex or the list of area modules.
 
 ```elixir
   defmodule Phone.NANP.AG do
-    use Helper.Country
+    use Helper.Country, match: regex
     field :regex, ~r/^(1)(268)([2-9].{6})/
     field :country, "Antigua and Barbuda"
     field :a2, "AG"
     field :a3, "ATG"
-    match :regex
   end
 ```
 
 
 ```elixir
   defmodule Phone.NANP.CA do
-    use Helper.Country
+    use Helper.Country, match: :modules
     field :country, "Canada"
     field :a2, "CA"
     field :a3, "CAN"
@@ -59,7 +57,6 @@ Required fields for an country module:
       Phone.NANP.CA.SK,
       Phone.NANP.CA.Territory
     ]
-    match :modules
   end
 ```
 

--- a/bench/phone_bench.exs
+++ b/bench/phone_bench.exs
@@ -1,0 +1,19 @@
+defmodule PhoneBench do
+  use Benchfella
+
+  @nanp_phone_number "12536301234"
+  @andorra_phone_number "376123456"
+  @zimbabwe_phone_number "2634333224"
+
+  bench "Phone.parse/1 with an NANP phone number" do
+    {:ok, _result} = Phone.parse(@nanp_phone_number)
+  end
+
+  bench "Phone.parse/1 with an Andorra phone number" do
+    {:ok, _result} = Phone.parse(@andorra_phone_number)
+  end
+
+  bench "Phone.parse/1 with a Zimbabwe phone number" do
+    {:ok, _result} = Phone.parse(@zimbabwe_phone_number)
+  end
+end

--- a/lib/helpers/country.ex
+++ b/lib/helpers/country.ex
@@ -1,10 +1,8 @@
 defmodule Helper.Country do
   @moduledoc false
-  defmacro __using__(_) do
-    quote do
-      import Helper.Country
-      @moduledoc false
-    end
+  defmacro __using__(opts \\ []) do
+    match_type = Keyword.get(opts, :match)
+    build_matcher(match_type)
   end
 
   defmacro field(name, value) do
@@ -15,6 +13,9 @@ defmodule Helper.Country do
 
   defp regex_matcher do
     quote do
+      import Helper.Country
+      @moduledoc false
+
       def match?(number) do
         Regex.match?(regex, number)
       end
@@ -52,6 +53,9 @@ defmodule Helper.Country do
 
   defp modules_matcher do
     quote do
+      import Helper.Country
+      @moduledoc false
+
       def match?(number) do
         ms = Enum.filter(modules, fn m -> m.match?(number) end)
         length(ms) > 0
@@ -77,7 +81,7 @@ defmodule Helper.Country do
     end
   end
 
-  defmacro match(matcher) do
+  defp build_matcher(matcher) do
     case matcher do
       :regex -> regex_matcher
       :modules -> modules_matcher

--- a/lib/helpers/country.ex
+++ b/lib/helpers/country.ex
@@ -2,7 +2,8 @@ defmodule Helper.Country do
   @moduledoc false
   defmacro __using__(opts \\ []) do
     match_type = Keyword.get(opts, :match)
-    build_matcher(match_type)
+    number_prefix = Keyword.get(opts, :number_prefix, "")
+    build_matcher(match_type, number_prefix)
   end
 
   defmacro field(name, value) do
@@ -11,14 +12,15 @@ defmodule Helper.Country do
     end
   end
 
-  defp regex_matcher do
+  defp regex_matcher(number_prefix) do
     quote do
       import Helper.Country
       @moduledoc false
 
-      def match?(number) do
+      def match?(unquote(number_prefix) <> _ = number) do
         Regex.match?(regex, number)
       end
+      def match?(_), do: false
 
       def builder(number) do
         [[_, code, area, number]] = Regex.scan(regex,number)
@@ -81,9 +83,9 @@ defmodule Helper.Country do
     end
   end
 
-  defp build_matcher(matcher) do
+  defp build_matcher(matcher, number_prefix) do
     case matcher do
-      :regex -> regex_matcher
+      :regex -> regex_matcher(number_prefix)
       :modules -> modules_matcher
       true ->
         raise ArgumentError, "You can only match against :regex or :modules, passed #{inspect matcher}"

--- a/lib/phone/ad.ex
+++ b/lib/phone/ad.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AD do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(376)()(.{6})/
   field :country, "Andorra"
   field :a2, "AD"
   field :a3, "AND"
-  match :regex
 end

--- a/lib/phone/ad.ex
+++ b/lib/phone/ad.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AD do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "376"
   field :regex, ~r/^(376)()(.{6})/
   field :country, "Andorra"
   field :a2, "AD"

--- a/lib/phone/ae.ex
+++ b/lib/phone/ae.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(971)(.)(.{7})/
   field :country, "United Arab Emirates"
   field :a2, "AE"
   field :a3, "ARE"
-  match :regex
 end

--- a/lib/phone/ae.ex
+++ b/lib/phone/ae.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "971"
   field :regex, ~r/^(971)(.)(.{7})/
   field :country, "United Arab Emirates"
   field :a2, "AE"

--- a/lib/phone/af.ex
+++ b/lib/phone/af.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AF do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "93"
   field :regex, ~r/^(93)(..)(.{7})/
   field :country, "Afghanistan"
   field :a2, "AF"

--- a/lib/phone/af.ex
+++ b/lib/phone/af.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AF do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(93)(..)(.{7})/
   field :country, "Afghanistan"
   field :a2, "AF"
   field :a3, "AFG"
-  match :regex
 end

--- a/lib/phone/al.ex
+++ b/lib/phone/al.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "355"
   field :regex, ~r/^(355)()(.{7})/
   field :country, "Albania"
   field :a2, "AL"

--- a/lib/phone/al.ex
+++ b/lib/phone/al.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(355)()(.{7})/
   field :country, "Albania"
   field :a2, "AL"
   field :a3, "ALB"
-  match :regex
 end

--- a/lib/phone/am.ex
+++ b/lib/phone/am.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(374)()(.{8})/
   field :country, "Armenia"
   field :a2, "AM"
   field :a3, "ARM"
-  match :regex
 end

--- a/lib/phone/am.ex
+++ b/lib/phone/am.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "374"
   field :regex, ~r/^(374)()(.{8})/
   field :country, "Armenia"
   field :a2, "AM"

--- a/lib/phone/ao.ex
+++ b/lib/phone/ao.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(244)()(9)/
   field :country, "Angola"
   field :a2, "AO"
   field :a3, "AGO"
-  match :regex
 end

--- a/lib/phone/ao.ex
+++ b/lib/phone/ao.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "244"
   field :regex, ~r/^(244)()(9)/
   field :country, "Angola"
   field :a2, "AO"

--- a/lib/phone/ar.ex
+++ b/lib/phone/ar.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(54)()(.{10})/
   field :country, "Argentina"
   field :a2, "AR"
   field :a3, "ARG"
-  match :regex
 end

--- a/lib/phone/ar.ex
+++ b/lib/phone/ar.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "54"
   field :regex, ~r/^(54)()(.{10})/
   field :country, "Argentina"
   field :a2, "AR"

--- a/lib/phone/at.ex
+++ b/lib/phone/at.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "43"
   field :regex, ~r/^(43)()(.+)/
   field :country, "Austria"
   field :a2, "AT"

--- a/lib/phone/at.ex
+++ b/lib/phone/at.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(43)()(.+)/
   field :country, "Austria"
   field :a2, "AT"
   field :a3, "AUT"
-  match :regex
 end

--- a/lib/phone/au.ex
+++ b/lib/phone/au.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "61"
   field :regex, ~r/^(61)([1-478])(.{8})/
   field :country, "Australia"
   field :a2, "AU"

--- a/lib/phone/au.ex
+++ b/lib/phone/au.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(61)([1-478])(.{8})/
   field :country, "Australia"
   field :a2, "AU"
   field :a3, "AUS"
-  match :regex
 end

--- a/lib/phone/aw.ex
+++ b/lib/phone/aw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(297)()(.{7})/
   field :country, "Aruba"
   field :a2, "AW"
   field :a3, "ABW"
-  match :regex
 end

--- a/lib/phone/aw.ex
+++ b/lib/phone/aw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "297"
   field :regex, ~r/^(297)()(.{7})/
   field :country, "Aruba"
   field :a2, "AW"

--- a/lib/phone/az.ex
+++ b/lib/phone/az.ex
@@ -1,8 +1,7 @@
 defmodule Phone.AZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(994)()(.{9})/
   field :country, "Azerbeijan"
   field :a2, "AZ"
   field :a3, "AZE"
-  match :regex
 end

--- a/lib/phone/az.ex
+++ b/lib/phone/az.ex
@@ -1,5 +1,6 @@
 defmodule Phone.AZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "994"
   field :regex, ~r/^(994)()(.{9})/
   field :country, "Azerbeijan"
   field :a2, "AZ"

--- a/lib/phone/ba.ex
+++ b/lib/phone/ba.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "387"
   field :regex, ~r/^(387)(..)(.{5,6})/
   field :country, "Bosnia and Herzegovina"
   field :a2, "BA"

--- a/lib/phone/ba.ex
+++ b/lib/phone/ba.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(387)(..)(.{5,6})/
   field :country, "Bosnia and Herzegovina"
   field :a2, "BA"
   field :a3, "BIH"
-  match :regex
 end

--- a/lib/phone/bd.ex
+++ b/lib/phone/bd.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BD do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "880"
   field :regex, ~r/^(880)()(.{10})/
   field :country, "Bangladesh"
   field :a2, "BD"

--- a/lib/phone/bd.ex
+++ b/lib/phone/bd.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BD do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(880)()(.{10})/
   field :country, "Bangladesh"
   field :a2, "BD"
   field :a3, "BGD"
-  match :regex
 end

--- a/lib/phone/be.ex
+++ b/lib/phone/be.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(32)()(.{9})/
   field :country, "Belgium"
   field :a2, "BE"
   field :a3, "BEL"
-  match :regex
 end

--- a/lib/phone/be.ex
+++ b/lib/phone/be.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "32"
   field :regex, ~r/^(32)()(.{9})/
   field :country, "Belgium"
   field :a2, "BE"

--- a/lib/phone/bg.ex
+++ b/lib/phone/bg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "359"
   field :regex, ~r/^(359)()(.{8,9})/
   field :country, "Bulgaria"
   field :a2, "BG"

--- a/lib/phone/bg.ex
+++ b/lib/phone/bg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(359)()(.{8,9})/
   field :country, "Bulgaria"
   field :a2, "BG"
   field :a3, "BGR"
-  match :regex
 end

--- a/lib/phone/bh.ex
+++ b/lib/phone/bh.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "973"
   field :regex, ~r/^(973)()(.{8})/
   field :country, "Bahrain"
   field :a2, "BH"

--- a/lib/phone/bh.ex
+++ b/lib/phone/bh.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(973)()(.{8})/
   field :country, "Bahrain"
   field :a2, "BH"
   field :a3, "BHR"
-  match :regex
 end

--- a/lib/phone/bi.ex
+++ b/lib/phone/bi.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "257"
   field :regex, ~r/^(257)()(.{8})/
   field :country, "Burundi"
   field :a2, "BI"

--- a/lib/phone/bi.ex
+++ b/lib/phone/bi.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(257)()(.{8})/
   field :country, "Burundi"
   field :a2, "BI"
   field :a3, "BDI"
-  match :regex
 end

--- a/lib/phone/bj.ex
+++ b/lib/phone/bj.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BJ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(229)()(.{8})/
   field :country, "Benin"
   field :a2, "BJ"
   field :a3, "BEN"
-  match :regex
 end

--- a/lib/phone/bj.ex
+++ b/lib/phone/bj.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BJ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "229"
   field :regex, ~r/^(229)()(.{8})/
   field :country, "Benin"
   field :a2, "BJ"

--- a/lib/phone/bn.ex
+++ b/lib/phone/bn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "673"
   field :regex, ~r/^(673)()(.{7})/
   field :country, "Brunei"
   field :a2, "BN"

--- a/lib/phone/bn.ex
+++ b/lib/phone/bn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(673)()(.{7})/
   field :country, "Brunei"
   field :a2, "BN"
   field :a3, "BRN"
-  match :regex
 end

--- a/lib/phone/bo.ex
+++ b/lib/phone/bo.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "591"
   field :regex, ~r/^(591)()(.{8})/
   field :country, "Bolivia"
   field :a2, "BO"

--- a/lib/phone/bo.ex
+++ b/lib/phone/bo.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(591)()(.{8})/
   field :country, "Bolivia"
   field :a2, "BO"
   field :a3, "BOL"
-  match :regex
 end

--- a/lib/phone/br.ex
+++ b/lib/phone/br.ex
@@ -1,5 +1,5 @@
 defmodule Phone.BR do
-  use Helper.Country
+  use Helper.Country, match: :modules
   field :country, "Brazil"
   field :a2, "BR"
   field :a3, "BRA"
@@ -19,5 +19,4 @@ defmodule Phone.BR do
     Phone.BR.SE, Phone.BR.SP,
     Phone.BR.TO
   ]
-  match :modules
 end

--- a/lib/phone/bt.ex
+++ b/lib/phone/bt.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(975)()(.{7,8})/
   field :country, "Bhutan"
   field :a2, "BT"
   field :a3, "BTN"
-  match :regex
 end

--- a/lib/phone/bt.ex
+++ b/lib/phone/bt.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "975"
   field :regex, ~r/^(975)()(.{7,8})/
   field :country, "Bhutan"
   field :a2, "BT"

--- a/lib/phone/bw.ex
+++ b/lib/phone/bw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "267"
   field :regex, ~r/^(267)()(.{7})/
   field :country, "Botswana"
   field :a2, "BW"

--- a/lib/phone/bw.ex
+++ b/lib/phone/bw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(267)()(.{7})/
   field :country, "Botswana"
   field :a2, "BW"
   field :a3, "BWA"
-  match :regex
 end

--- a/lib/phone/by.ex
+++ b/lib/phone/by.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "375"
   field :regex, ~r/^(375)()(.{9})/
   field :country, "Belarus"
   field :a2, "BY"

--- a/lib/phone/by.ex
+++ b/lib/phone/by.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(375)()(.{9})/
   field :country, "Belarus"
   field :a2, "BY"
   field :a3, "BLR"
-  match :regex
 end

--- a/lib/phone/bz.ex
+++ b/lib/phone/bz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.BZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "501"
   field :regex, ~r/^(501)()(.{7})/
   field :country, "Belize"
   field :a2, "BZ"

--- a/lib/phone/bz.ex
+++ b/lib/phone/bz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.BZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(501)()(.{7})/
   field :country, "Belize"
   field :a2, "BZ"
   field :a3, "BLZ"
-  match :regex
 end

--- a/lib/phone/cd.ex
+++ b/lib/phone/cd.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CD do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(243)(.)(.{7})/
   field :country, "Democratic Republic of Congo"
   field :a2, "CD"
   field :a3, "COD"
-  match :regex
 end

--- a/lib/phone/cd.ex
+++ b/lib/phone/cd.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CD do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "243"
   field :regex, ~r/^(243)(.)(.{7})/
   field :country, "Democratic Republic of Congo"
   field :a2, "CD"

--- a/lib/phone/cf.ex
+++ b/lib/phone/cf.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CF do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "236"
   field :regex, ~r/^(236)()(.{8})/
   field :country, "Central African Republic"
   field :a2, "CF"

--- a/lib/phone/cf.ex
+++ b/lib/phone/cf.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CF do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(236)()(.{8})/
   field :country, "Central African Republic"
   field :a2, "CF"
   field :a3, "CAF"
-  match :regex
 end

--- a/lib/phone/cg.ex
+++ b/lib/phone/cg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "242"
   field :regex, ~r/^(242)(.{4})(.{5})/
   field :country, "Congo"
   field :a2, "CG"

--- a/lib/phone/cg.ex
+++ b/lib/phone/cg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(242)(.{4})(.{5})/
   field :country, "Congo"
   field :a2, "CG"
   field :a3, "COG"
-  match :regex
 end

--- a/lib/phone/ch.ex
+++ b/lib/phone/ch.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "41"
   field :regex, ~r/^(41)()(.{9,10})/
   field :country, "Switzerland"
   field :a2, "CH"

--- a/lib/phone/ch.ex
+++ b/lib/phone/ch.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(41)()(.{9,10})/
   field :country, "Switzerland"
   field :a2, "CH"
   field :a3, "CHE"
-  match :regex
 end

--- a/lib/phone/ci.ex
+++ b/lib/phone/ci.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(225)(..)(.{6})/
   field :country, "Ivory Coast"
   field :a2, "CI"
   field :a3, "CIV"
-  match :regex
 end

--- a/lib/phone/ci.ex
+++ b/lib/phone/ci.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "225"
   field :regex, ~r/^(225)(..)(.{6})/
   field :country, "Ivory Coast"
   field :a2, "CI"

--- a/lib/phone/ck.ex
+++ b/lib/phone/ck.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(682)()(.{5})/
   field :country, "Cook Islands"
   field :a2, "CK"
   field :a3, "COK"
-  match :regex
 end

--- a/lib/phone/ck.ex
+++ b/lib/phone/ck.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "682"
   field :regex, ~r/^(682)()(.{5})/
   field :country, "Cook Islands"
   field :a2, "CK"

--- a/lib/phone/cl.ex
+++ b/lib/phone/cl.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "56"
   field :regex, ~r/^(56)()(.{9})/
   field :country, "Chile"
   field :a2, "CL"

--- a/lib/phone/cl.ex
+++ b/lib/phone/cl.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(56)()(.{9})/
   field :country, "Chile"
   field :a2, "CL"
   field :a3, "CHL"
-  match :regex
 end

--- a/lib/phone/cm.ex
+++ b/lib/phone/cm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "237"
   field :regex, ~r/^(237)()(.{8})/
   field :country, "Cameroon"
   field :a2, "CM"

--- a/lib/phone/cm.ex
+++ b/lib/phone/cm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(237)()(.{8})/
   field :country, "Cameroon"
   field :a2, "CM"
   field :a3, "CMR"
-  match :regex
 end

--- a/lib/phone/cn.ex
+++ b/lib/phone/cn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(86)()(.+)/
   field :country, "China"
   field :a2, "CN"
   field :a3, "CHN"
-  match :regex
 end

--- a/lib/phone/cn.ex
+++ b/lib/phone/cn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "86"
   field :regex, ~r/^(86)()(.+)/
   field :country, "China"
   field :a2, "CN"

--- a/lib/phone/co.ex
+++ b/lib/phone/co.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "57"
   field :regex, ~r/^(57)()(.+)/
   field :country, "Colombia"
   field :a2, "CO"

--- a/lib/phone/co.ex
+++ b/lib/phone/co.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(57)()(.+)/
   field :country, "Colombia"
   field :a2, "CO"
   field :a3, "COL"
-  match :regex
 end

--- a/lib/phone/countries.ex
+++ b/lib/phone/countries.ex
@@ -1,5 +1,5 @@
 defmodule Phone.Countries do
-  use Helper.Country
+  use Helper.Country, match: :modules
   field :modules, [
     Phone.AD, Phone.AE, Phone.AF, Phone.AL, Phone.AM, Phone.AO,
     Phone.AR, Phone.AT, Phone.AU, Phone.AW, Phone.AZ, Phone.BA,
@@ -36,5 +36,4 @@ defmodule Phone.Countries do
     Phone.VU, Phone.WF, Phone.WS, Phone.YE, Phone.ZA, Phone.ZM,
     Phone.ZW, Phone.NANP
   ]
-  match :modules
 end

--- a/lib/phone/cr.ex
+++ b/lib/phone/cr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "506"
   field :regex, ~r/^(506)()(.{8})/
   field :country, "Costa Rica"
   field :a2, "CR"

--- a/lib/phone/cr.ex
+++ b/lib/phone/cr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(506)()(.{8})/
   field :country, "Costa Rica"
   field :a2, "CR"
   field :a3, "CRI"
-  match :regex
 end

--- a/lib/phone/cu.ex
+++ b/lib/phone/cu.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "53"
   field :regex, ~r/^(53)()(.{8})/
   field :country, "Cuba"
   field :a2, "CU"

--- a/lib/phone/cu.ex
+++ b/lib/phone/cu.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(53)()(.{8})/
   field :country, "Cuba"
   field :a2, "CU"
   field :a3, "CUB"
-  match :regex
 end

--- a/lib/phone/cv.ex
+++ b/lib/phone/cv.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CV do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "238"
   field :regex, ~r/^(238)()(.{7})/
   field :country, "Cape Verde"
   field :a2, "CV"

--- a/lib/phone/cv.ex
+++ b/lib/phone/cv.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CV do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(238)()(.{7})/
   field :country, "Cape Verde"
   field :a2, "CV"
   field :a3, "CPV"
-  match :regex
 end

--- a/lib/phone/cw.ex
+++ b/lib/phone/cw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(599)(9)(.{7})/
   field :country, "Curaçao"
   field :a2, "CW"
   field :a3, "CUW"
-  match :regex
 end

--- a/lib/phone/cw.ex
+++ b/lib/phone/cw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "599"
   field :regex, ~r/^(599)(9)(.{7})/
   field :country, "Curaçao"
   field :a2, "CW"

--- a/lib/phone/cy.ex
+++ b/lib/phone/cy.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(357)()(.{7,8})/
   field :country, "Cyprus"
   field :a2, "CY"
   field :a3, "CYP"
-  match :regex
 end

--- a/lib/phone/cy.ex
+++ b/lib/phone/cy.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "357"
   field :regex, ~r/^(357)()(.{7,8})/
   field :country, "Cyprus"
   field :a2, "CY"

--- a/lib/phone/cz.ex
+++ b/lib/phone/cz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.CZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(420)()(.{9})/
   field :country, "Czech Republic"
   field :a2, "CZ"
   field :a3, "CZE"
-  match :regex
 end

--- a/lib/phone/cz.ex
+++ b/lib/phone/cz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.CZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "420"
   field :regex, ~r/^(420)()(.{9})/
   field :country, "Czech Republic"
   field :a2, "CZ"

--- a/lib/phone/de.ex
+++ b/lib/phone/de.ex
@@ -1,5 +1,6 @@
 defmodule Phone.DE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "49"
   field :regex, ~r/^(49)()(.{10,11})/
   field :country, "Germany"
   field :a2, "DE"

--- a/lib/phone/de.ex
+++ b/lib/phone/de.ex
@@ -1,8 +1,7 @@
 defmodule Phone.DE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(49)()(.{10,11})/
   field :country, "Germany"
   field :a2, "DE"
   field :a3, "DEU"
-  match :regex
 end

--- a/lib/phone/dj.ex
+++ b/lib/phone/dj.ex
@@ -1,8 +1,7 @@
 defmodule Phone.DJ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(253)()(.{8})/
   field :country, "Djibouti"
   field :a2, "DJ"
   field :a3, "DJI"
-  match :regex
 end

--- a/lib/phone/dj.ex
+++ b/lib/phone/dj.ex
@@ -1,5 +1,6 @@
 defmodule Phone.DJ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "253"
   field :regex, ~r/^(253)()(.{8})/
   field :country, "Djibouti"
   field :a2, "DJ"

--- a/lib/phone/dk.ex
+++ b/lib/phone/dk.ex
@@ -1,5 +1,6 @@
 defmodule Phone.DK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "45"
   field :regex, ~r/^(45)()(.{8})/
   field :country, "Denmark"
   field :a2, "DK"

--- a/lib/phone/dk.ex
+++ b/lib/phone/dk.ex
@@ -1,8 +1,7 @@
 defmodule Phone.DK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(45)()(.{8})/
   field :country, "Denmark"
   field :a2, "DK"
   field :a3, "DNK"
-  match :regex
 end

--- a/lib/phone/dz.ex
+++ b/lib/phone/dz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.DZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "213"
   field :regex, ~r/^(213)()(.{8})/
   field :country, "Algeria"
   field :a2, "DZ"

--- a/lib/phone/dz.ex
+++ b/lib/phone/dz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.DZ do
-   use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(213)()(.{8})/
   field :country, "Algeria"
   field :a2, "DZ"
   field :a3, "DZA"
-  match :regex
 end

--- a/lib/phone/ec.ex
+++ b/lib/phone/ec.ex
@@ -1,8 +1,7 @@
 defmodule Phone.EC do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(593)(..)(.{7})/
   field :country, "Ecuador"
   field :a2, "EC"
   field :a3, "ECU"
-  match :regex
 end

--- a/lib/phone/ec.ex
+++ b/lib/phone/ec.ex
@@ -1,5 +1,6 @@
 defmodule Phone.EC do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "593"
   field :regex, ~r/^(593)(..)(.{7})/
   field :country, "Ecuador"
   field :a2, "EC"

--- a/lib/phone/ee.ex
+++ b/lib/phone/ee.ex
@@ -1,5 +1,6 @@
 defmodule Phone.EE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "372"
   field :regex, ~r/^(372)()(.{7,8})/
   field :country, "Estonia"
   field :a2, "EE"

--- a/lib/phone/ee.ex
+++ b/lib/phone/ee.ex
@@ -1,8 +1,7 @@
 defmodule Phone.EE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(372)()(.{7,8})/
   field :country, "Estonia"
   field :a2, "EE"
   field :a3, "EST"
-  match :regex
 end

--- a/lib/phone/eg.ex
+++ b/lib/phone/eg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.EG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "20"
   field :regex, ~r/^(20)()(.+)/
   field :country, "Egypt"
   field :a2, "EG"

--- a/lib/phone/eg.ex
+++ b/lib/phone/eg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.EG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(20)()(.+)/
   field :country, "Egypt"
   field :a2, "EG"
   field :a3, "EGY"
-  match :regex
 end

--- a/lib/phone/er.ex
+++ b/lib/phone/er.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ER do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "291"
   field :regex, ~r/^(291)(.)(.{6})/
   field :country, "Eritrea"
   field :a2, "ER"

--- a/lib/phone/er.ex
+++ b/lib/phone/er.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ER do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(291)(.)(.{6})/
   field :country, "Eritrea"
   field :a2, "ER"
   field :a3, "ERI"
-  match :regex
 end

--- a/lib/phone/es.ex
+++ b/lib/phone/es.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ES do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "34"
   field :regex, ~r/^(34)()(.{9})/
   field :country, "Spain"
   field :a2, "ES"

--- a/lib/phone/es.ex
+++ b/lib/phone/es.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ES do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(34)()(.{9})/
   field :country, "Spain"
   field :a2, "ES"
   field :a3, "ESP"
-  match :regex
 end

--- a/lib/phone/et.ex
+++ b/lib/phone/et.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ET do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "251"
   field :regex, ~r/^(251)(..)(.{7})/
   field :country, "Ethiopia"
   field :a2, "ET"

--- a/lib/phone/et.ex
+++ b/lib/phone/et.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ET do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(251)(..)(.{7})/
   field :country, "Ethiopia"
   field :a2, "ET"
   field :a3, "ETH"
-  match :regex
 end

--- a/lib/phone/fi.ex
+++ b/lib/phone/fi.ex
@@ -1,5 +1,6 @@
 defmodule Phone.FI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "358"
   field :regex, ~r/^(358)()(.+)/
   field :country, "Finland"
   field :a2, "FI"

--- a/lib/phone/fi.ex
+++ b/lib/phone/fi.ex
@@ -1,8 +1,7 @@
 defmodule Phone.FI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(358)()(.+)/
   field :country, "Finland"
   field :a2, "FI"
   field :a3, "FIN"
-  match :regex
 end

--- a/lib/phone/fj.ex
+++ b/lib/phone/fj.ex
@@ -1,8 +1,7 @@
 defmodule Phone.FJ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(679)()(.{7})/
   field :country, "Fiji"
   field :a2, "FJ"
   field :a3, "FJI"
-  match :regex
 end

--- a/lib/phone/fj.ex
+++ b/lib/phone/fj.ex
@@ -1,5 +1,6 @@
 defmodule Phone.FJ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "679"
   field :regex, ~r/^(679)()(.{7})/
   field :country, "Fiji"
   field :a2, "FJ"

--- a/lib/phone/fm.ex
+++ b/lib/phone/fm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.FM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "691"
   field :regex, ~r/^(691)()(.{7})/
   field :country, "Micronesia"
   field :a2, "FM"

--- a/lib/phone/fm.ex
+++ b/lib/phone/fm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.FM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(691)()(.{7})/
   field :country, "Micronesia"
   field :a2, "FM"
   field :a3, "FSM"
-  match :regex
 end

--- a/lib/phone/fo.ex
+++ b/lib/phone/fo.ex
@@ -1,8 +1,7 @@
 defmodule Phone.FO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(298)()(.{6})/
   field :country, "Faroe Islands"
   field :a2, "FO"
   field :a3, "FRO"
-  match :regex
 end

--- a/lib/phone/fo.ex
+++ b/lib/phone/fo.ex
@@ -1,5 +1,6 @@
 defmodule Phone.FO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "298"
   field :regex, ~r/^(298)()(.{6})/
   field :country, "Faroe Islands"
   field :a2, "FO"

--- a/lib/phone/fr.ex
+++ b/lib/phone/fr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.FR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(33)()(.{9})/
   field :country, "France"
   field :a2, "FR"
   field :a3, "FRA"
-  match :regex
 end

--- a/lib/phone/fr.ex
+++ b/lib/phone/fr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.FR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "33"
   field :regex, ~r/^(33)()(.{9})/
   field :country, "France"
   field :a2, "FR"

--- a/lib/phone/ga.ex
+++ b/lib/phone/ga.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "241"
   field :regex, ~r/^(241)()(.{7})/
   field :country, "Gabon"
   field :a2, "GA"

--- a/lib/phone/ga.ex
+++ b/lib/phone/ga.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(241)()(.{7})/
   field :country, "Gabon"
   field :a2, "GA"
   field :a3, "GAB"
-  match :regex
 end

--- a/lib/phone/gb.ex
+++ b/lib/phone/gb.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GB do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(44)()(.{10})/
   field :country, "United Kingdom"
   field :a2, "GB"
   field :a3, "GBR"
-  match :regex
 end

--- a/lib/phone/gb.ex
+++ b/lib/phone/gb.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GB do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "44"
   field :regex, ~r/^(44)()(.{10})/
   field :country, "United Kingdom"
   field :a2, "GB"

--- a/lib/phone/ge.ex
+++ b/lib/phone/ge.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "995"
   field :regex, ~r/^(995)(.{3})(.{6})/
   field :country, "Georgia"
   field :a2, "GE"

--- a/lib/phone/ge.ex
+++ b/lib/phone/ge.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(995)(.{3})(.{6})/
   field :country, "Georgia"
   field :a2, "GE"
   field :a3, "GEO"
-  match :regex
 end

--- a/lib/phone/gf.ex
+++ b/lib/phone/gf.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GF do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "594"
   field :regex, ~r/^(594)([5|6]94)(.{6})/
   field :country, "French Guiana"
   field :a2, "GF"

--- a/lib/phone/gf.ex
+++ b/lib/phone/gf.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GF do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(594)([5|6]94)(.{6})/
   field :country, "French Guiana"
   field :a2, "GF"
   field :a3, "GUF"
-  match :regex
 end

--- a/lib/phone/gh.ex
+++ b/lib/phone/gh.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "233"
   field :regex, ~r/^(233)(..)(.{7})/
   field :country, "Ghana"
   field :a2, "GH"

--- a/lib/phone/gh.ex
+++ b/lib/phone/gh.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(233)(..)(.{7})/
   field :country, "Ghana"
   field :a2, "GH"
   field :a3, "GHA"
-  match :regex
 end

--- a/lib/phone/gi.ex
+++ b/lib/phone/gi.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(350)()(.{8})/
   field :country, "Gibraltar"
   field :a2, "GI"
   field :a3, "GIB"
-  match :regex
 end

--- a/lib/phone/gi.ex
+++ b/lib/phone/gi.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "350"
   field :regex, ~r/^(350)()(.{8})/
   field :country, "Gibraltar"
   field :a2, "GI"

--- a/lib/phone/gl.ex
+++ b/lib/phone/gl.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "299"
   field :regex, ~r/^(299)(..)(.{4})/
   field :country, "Greenland"
   field :a2, "GL"

--- a/lib/phone/gl.ex
+++ b/lib/phone/gl.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(299)(..)(.{4})/
   field :country, "Greenland"
   field :a2, "GL"
   field :a3, "GRL"
-  match :regex
 end

--- a/lib/phone/gm.ex
+++ b/lib/phone/gm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "220"
   field :regex, ~r/^(220)()(.{7})/
   field :country, "Gambia"
   field :a2, "GM"

--- a/lib/phone/gm.ex
+++ b/lib/phone/gm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(220)()(.{7})/
   field :country, "Gambia"
   field :a2, "GM"
   field :a3, "GMB"
-  match :regex
 end

--- a/lib/phone/gn.ex
+++ b/lib/phone/gn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(224)()(.{8})/
   field :country, "Guinea"
   field :a2, "GN"
   field :a3, "GIN"
-  match :regex
 end

--- a/lib/phone/gn.ex
+++ b/lib/phone/gn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "224"
   field :regex, ~r/^(224)()(.{8})/
   field :country, "Guinea"
   field :a2, "GN"

--- a/lib/phone/gq.ex
+++ b/lib/phone/gq.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GQ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "240"
   field :regex, ~r/^(240)()(.{9})/
   field :country, "Equatorial Guinea"
   field :a2, "GQ"

--- a/lib/phone/gq.ex
+++ b/lib/phone/gq.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GQ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(240)()(.{9})/
   field :country, "Equatorial Guinea"
   field :a2, "GQ"
   field :a3, "GNQ"
-  match :regex
 end

--- a/lib/phone/gr.ex
+++ b/lib/phone/gr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(30)()(.{10})/
   field :country, "Greece"
   field :a2, "GR"
   field :a3, "GRC"
-  match :regex
 end

--- a/lib/phone/gr.ex
+++ b/lib/phone/gr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "30"
   field :regex, ~r/^(30)()(.{10})/
   field :country, "Greece"
   field :a2, "GR"

--- a/lib/phone/gt.ex
+++ b/lib/phone/gt.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(502)()(.{8})/
   field :country, "Guatemala"
   field :a2, "GT"
   field :a3, "GTM"
-  match :regex
 end

--- a/lib/phone/gt.ex
+++ b/lib/phone/gt.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "502"
   field :regex, ~r/^(502)()(.{8})/
   field :country, "Guatemala"
   field :a2, "GT"

--- a/lib/phone/gw.ex
+++ b/lib/phone/gw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "245"
   field :regex, ~r/^(245)()(.{7})/
   field :country, "Guinea-Bissau"
   field :a2, "GW"

--- a/lib/phone/gw.ex
+++ b/lib/phone/gw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(245)()(.{7})/
   field :country, "Guinea-Bissau"
   field :a2, "GW"
   field :a3, "GNB"
-  match :regex
 end

--- a/lib/phone/gy.ex
+++ b/lib/phone/gy.ex
@@ -1,8 +1,7 @@
 defmodule Phone.GY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(592)()(.{8})/
   field :country, "Guyana"
   field :a2, "GY"
   field :a3, "GUY"
-  match :regex
 end

--- a/lib/phone/gy.ex
+++ b/lib/phone/gy.ex
@@ -1,5 +1,6 @@
 defmodule Phone.GY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "592"
   field :regex, ~r/^(592)()(.{8})/
   field :country, "Guyana"
   field :a2, "GY"

--- a/lib/phone/hk.ex
+++ b/lib/phone/hk.ex
@@ -1,8 +1,7 @@
 defmodule Phone.HK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(852)()(.{8})/
   field :country, "Hong Kong"
   field :a2, "HK"
   field :a3, "HKG"
-  match :regex
 end

--- a/lib/phone/hk.ex
+++ b/lib/phone/hk.ex
@@ -1,5 +1,6 @@
 defmodule Phone.HK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "852"
   field :regex, ~r/^(852)()(.{8})/
   field :country, "Hong Kong"
   field :a2, "HK"

--- a/lib/phone/hn.ex
+++ b/lib/phone/hn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.HN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "504"
   field :regex, ~r/^(504)()(.{8})/
   field :country, "Honduras"
   field :a2, "HN"

--- a/lib/phone/hn.ex
+++ b/lib/phone/hn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.HN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(504)()(.{8})/
   field :country, "Honduras"
   field :a2, "HN"
   field :a3, "HND"
-  match :regex
 end

--- a/lib/phone/hr.ex
+++ b/lib/phone/hr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.HR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(385)()(.{8,9})/
   field :country, "Croatia"
   field :a2, "HR"
   field :a3, "HRV"
-  match :regex
 end

--- a/lib/phone/hr.ex
+++ b/lib/phone/hr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.HR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "385"
   field :regex, ~r/^(385)()(.{8,9})/
   field :country, "Croatia"
   field :a2, "HR"

--- a/lib/phone/ht.ex
+++ b/lib/phone/ht.ex
@@ -1,8 +1,7 @@
 defmodule Phone.HT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(509)()(.{8})/
   field :country, "Haiti"
   field :a2, "HT"
   field :a3, "HTI"
-  match :regex
 end

--- a/lib/phone/ht.ex
+++ b/lib/phone/ht.ex
@@ -1,5 +1,6 @@
 defmodule Phone.HT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "509"
   field :regex, ~r/^(509)()(.{8})/
   field :country, "Haiti"
   field :a2, "HT"

--- a/lib/phone/hu.ex
+++ b/lib/phone/hu.ex
@@ -1,8 +1,7 @@
 defmodule Phone.HU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(36)()(.{8,9})/
   field :country, "Hungary"
   field :a2, "HU"
   field :a3, "HUN"
-  match :regex
 end

--- a/lib/phone/hu.ex
+++ b/lib/phone/hu.ex
@@ -1,5 +1,6 @@
 defmodule Phone.HU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "36"
   field :regex, ~r/^(36)()(.{8,9})/
   field :country, "Hungary"
   field :a2, "HU"

--- a/lib/phone/id.ex
+++ b/lib/phone/id.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ID do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "62"
   field :regex, ~r/^(62)()(.+)/
   field :country, "Indonesia"
   field :a2, "ID"

--- a/lib/phone/id.ex
+++ b/lib/phone/id.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ID do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(62)()(.+)/
   field :country, "Indonesia"
   field :a2, "ID"
   field :a3, "IDN"
-  match :regex
 end

--- a/lib/phone/ie.ex
+++ b/lib/phone/ie.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(353)(..)(.{7})/
   field :country, "Ireland"
   field :a2, "IE"
   field :a3, "IRL"
-  match :regex
 end

--- a/lib/phone/ie.ex
+++ b/lib/phone/ie.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "353"
   field :regex, ~r/^(353)(..)(.{7})/
   field :country, "Ireland"
   field :a2, "IE"

--- a/lib/phone/il.ex
+++ b/lib/phone/il.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(972)()(.{8,9})/
   field :country, "Israel"
   field :a2, "IL"
   field :a3, "ISR"
-  match :regex
 end

--- a/lib/phone/il.ex
+++ b/lib/phone/il.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "972"
   field :regex, ~r/^(972)()(.{8,9})/
   field :country, "Israel"
   field :a2, "IL"

--- a/lib/phone/in.ex
+++ b/lib/phone/in.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(91)()(.+)/
   field :country, "India"
   field :a2, "IN"
   field :a3, "IND"
-  match :regex
 end

--- a/lib/phone/in.ex
+++ b/lib/phone/in.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "91"
   field :regex, ~r/^(91)()(.+)/
   field :country, "India"
   field :a2, "IN"

--- a/lib/phone/io.ex
+++ b/lib/phone/io.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(246)() (.{7})/
   field :country, "British Indian Ocean Territory"
   field :a2, "IO"
   field :a3, "IOT"
-  match :regex
 end

--- a/lib/phone/io.ex
+++ b/lib/phone/io.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "246"
   field :regex, ~r/^(246)() (.{7})/
   field :country, "British Indian Ocean Territory"
   field :a2, "IO"

--- a/lib/phone/iq.ex
+++ b/lib/phone/iq.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IQ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "964"
   field :regex, ~r/^(964)()(.+)/
   field :country, "Iraq"
   field :a2, "IQ"

--- a/lib/phone/iq.ex
+++ b/lib/phone/iq.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IQ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(964)()(.+)/
   field :country, "Iraq"
   field :a2, "IQ"
   field :a3, "IRQ"
-  match :regex
 end

--- a/lib/phone/ir.ex
+++ b/lib/phone/ir.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "98"
   field :regex, ~r/^(98)()(.+)/
   field :country, "Iran"
   field :a2, "IR"

--- a/lib/phone/ir.ex
+++ b/lib/phone/ir.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(98)()(.+)/
   field :country, "Iran"
   field :a2, "IR"
   field :a3, "IRN"
-  match :regex
 end

--- a/lib/phone/is.ex
+++ b/lib/phone/is.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "354"
   field :regex, ~r/^(354)()(.{7})/
   field :country, "Iceland"
   field :a2, "IS"

--- a/lib/phone/is.ex
+++ b/lib/phone/is.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(354)()(.{7})/
   field :country, "Iceland"
   field :a2, "IS"
   field :a3, "ISL"
-  match :regex
 end

--- a/lib/phone/it.ex
+++ b/lib/phone/it.ex
@@ -1,5 +1,6 @@
 defmodule Phone.IT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "39"
   field :regex, ~r/^(39)()(.{9,10})/
   field :country, "Italy"
   field :a2, "IT"

--- a/lib/phone/it.ex
+++ b/lib/phone/it.ex
@@ -1,8 +1,7 @@
 defmodule Phone.IT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(39)()(.{9,10})/
   field :country, "Italy"
   field :a2, "IT"
   field :a3, "ITA"
-  match :regex
 end

--- a/lib/phone/jo.ex
+++ b/lib/phone/jo.ex
@@ -1,8 +1,7 @@
 defmodule Phone.JO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(962)(.)(.{7,8})/
   field :country, "Jordan"
   field :a2, "JO"
   field :a3, "JOR"
-  match :regex
 end

--- a/lib/phone/jo.ex
+++ b/lib/phone/jo.ex
@@ -1,5 +1,6 @@
 defmodule Phone.JO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "962"
   field :regex, ~r/^(962)(.)(.{7,8})/
   field :country, "Jordan"
   field :a2, "JO"

--- a/lib/phone/jp.ex
+++ b/lib/phone/jp.ex
@@ -1,5 +1,6 @@
 defmodule Phone.JP do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "81"
   field :regex, ~r/^(81)()(.+)/
   field :country, "Japan"
   field :a2, "JP"

--- a/lib/phone/jp.ex
+++ b/lib/phone/jp.ex
@@ -1,8 +1,7 @@
 defmodule Phone.JP do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(81)()(.+)/
   field :country, "Japan"
   field :a2, "JP"
   field :a3, "JPN"
-  match :regex
 end

--- a/lib/phone/ke.ex
+++ b/lib/phone/ke.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "254"
   field :regex, ~r/^(254)()(.+)/
   field :country, "Kenya"
   field :a2, "KE"

--- a/lib/phone/ke.ex
+++ b/lib/phone/ke.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(254)()(.+)/
   field :country, "Kenya"
   field :a2, "KE"
   field :a3, "KEN"
-  match :regex
 end

--- a/lib/phone/kg.ex
+++ b/lib/phone/kg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(996)()(.{9})/
   field :country, "Kyrgyzstan"
   field :a2, "KG"
   field :a3, "KGZ"
-  match :regex
 end

--- a/lib/phone/kg.ex
+++ b/lib/phone/kg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "996"
   field :regex, ~r/^(996)()(.{9})/
   field :country, "Kyrgyzstan"
   field :a2, "KG"

--- a/lib/phone/kh.ex
+++ b/lib/phone/kh.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(855)(..)(.{6,7})/
   field :country, "Cambodia"
   field :a2, "KH"
   field :a3, "KHM"
-  match :regex
 end

--- a/lib/phone/kh.ex
+++ b/lib/phone/kh.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "855"
   field :regex, ~r/^(855)(..)(.{6,7})/
   field :country, "Cambodia"
   field :a2, "KH"

--- a/lib/phone/ki.ex
+++ b/lib/phone/ki.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(686)()(.{5})/
   field :country, "Kiribati"
   field :a2, "KI"
   field :a3, "KIR"
-  match :regex
 end

--- a/lib/phone/ki.ex
+++ b/lib/phone/ki.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "686"
   field :regex, ~r/^(686)()(.{5})/
   field :country, "Kiribati"
   field :a2, "KI"

--- a/lib/phone/km.ex
+++ b/lib/phone/km.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "269"
   field :regex, ~r/^(269)(.{3})(.{4})/
   field :country, "Comoros"
   field :a2, "KM"

--- a/lib/phone/km.ex
+++ b/lib/phone/km.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(269)(.{3})(.{4})/
   field :country, "Comoros"
   field :a2, "KM"
   field :a3, "COM"
-  match :regex
 end

--- a/lib/phone/kp.ex
+++ b/lib/phone/kp.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KP do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "850"
   field :regex, ~r/^(850)()(.+)/
   field :country, "North Korea"
   field :a2, "KP"

--- a/lib/phone/kp.ex
+++ b/lib/phone/kp.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KP do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(850)()(.+)/
   field :country, "North Korea"
   field :a2, "KP"
   field :a3, "PRK"
-  match :regex
 end

--- a/lib/phone/kr.ex
+++ b/lib/phone/kr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(82)(.{1,2})(.{7,8})/
   field :country, "South Korea"
   field :a2, "KR"
   field :a3, "KOR"
-  match :regex
 end

--- a/lib/phone/kr.ex
+++ b/lib/phone/kr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "82"
   field :regex, ~r/^(82)(.{1,2})(.{7,8})/
   field :country, "South Korea"
   field :a2, "KR"

--- a/lib/phone/kw.ex
+++ b/lib/phone/kw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "965"
   field :regex, ~r/^(965)()(.{8})/
   field :country, "Kuwait"
   field :a2, "KW"

--- a/lib/phone/kw.ex
+++ b/lib/phone/kw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(965)()(.{8})/
   field :country, "Kuwait"
   field :a2, "KW"
   field :a3, "KWT"
-  match :regex
 end

--- a/lib/phone/kz.ex
+++ b/lib/phone/kz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.KZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(7)([67]..)(.{7})/
   field :country, "Kazakhstan"
   field :a2, "KZ"
   field :a3, "KAZ"
-  match :regex
 end

--- a/lib/phone/kz.ex
+++ b/lib/phone/kz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.KZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "7"
   field :regex, ~r/^(7)([67]..)(.{7})/
   field :country, "Kazakhstan"
   field :a2, "KZ"

--- a/lib/phone/la.ex
+++ b/lib/phone/la.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(856)(..)(.+)/
   field :country, "Laos"
   field :a2, "LA"
   field :a3, "LAO"
-  match :regex
 end

--- a/lib/phone/la.ex
+++ b/lib/phone/la.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "856"
   field :regex, ~r/^(856)(..)(.+)/
   field :country, "Laos"
   field :a2, "LA"

--- a/lib/phone/lb.ex
+++ b/lib/phone/lb.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LB do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(961)(.{1,2})(.{6})/
   field :country, "Lebanon"
   field :a2, "LB"
   field :a3, "LBN"
-  match :regex
 end

--- a/lib/phone/lb.ex
+++ b/lib/phone/lb.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LB do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "961"
   field :regex, ~r/^(961)(.{1,2})(.{6})/
   field :country, "Lebanon"
   field :a2, "LB"

--- a/lib/phone/li.ex
+++ b/lib/phone/li.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(423)()(.{7})/
   field :country, "Liechtenstein"
   field :a2, "LI"
   field :a3, "LIE"
-  match :regex
 end

--- a/lib/phone/li.ex
+++ b/lib/phone/li.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "423"
   field :regex, ~r/^(423)()(.{7})/
   field :country, "Liechtenstein"
   field :a2, "LI"

--- a/lib/phone/lk.ex
+++ b/lib/phone/lk.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "94"
   field :regex, ~r/^(94)()(.{9})/
   field :country, "Sri Lanka"
   field :a2, "LK"

--- a/lib/phone/lk.ex
+++ b/lib/phone/lk.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(94)()(.{9})/
   field :country, "Sri Lanka"
   field :a2, "LK"
   field :a3, "LKA"
-  match :regex
 end

--- a/lib/phone/lr.ex
+++ b/lib/phone/lr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(231)()(.{7,9})/
   field :country, "Liberia"
   field :a2, "LR"
   field :a3, "LBR"
-  match :regex
 end

--- a/lib/phone/lr.ex
+++ b/lib/phone/lr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "231"
   field :regex, ~r/^(231)()(.{7,9})/
   field :country, "Liberia"
   field :a2, "LR"

--- a/lib/phone/ls.ex
+++ b/lib/phone/ls.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "266"
   field :regex, ~r/^(266)(..)(.{6})/
   field :country, "Lesotho"
   field :a2, "LS"

--- a/lib/phone/ls.ex
+++ b/lib/phone/ls.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(266)(..)(.{6})/
   field :country, "Lesotho"
   field :a2, "LS"
   field :a3, "LSO"
-  match :regex
 end

--- a/lib/phone/lt.ex
+++ b/lib/phone/lt.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "370"
   field :regex, ~r/^(370)()(.{8})/
   field :country, "Lithuania"
   field :a2, "LT"

--- a/lib/phone/lt.ex
+++ b/lib/phone/lt.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(370)()(.{8})/
   field :country, "Lithuania"
   field :a2, "LT"
   field :a3, "LTU"
-  match :regex
 end

--- a/lib/phone/lu.ex
+++ b/lib/phone/lu.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(352)()(.+)/
   field :country, "Luxembourg"
   field :a2, "LU"
   field :a3, "LUX"
-  match :regex
 end

--- a/lib/phone/lu.ex
+++ b/lib/phone/lu.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "352"
   field :regex, ~r/^(352)()(.+)/
   field :country, "Luxembourg"
   field :a2, "LU"

--- a/lib/phone/lv.ex
+++ b/lib/phone/lv.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LV do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "371"
   field :regex, ~r/^(371)()(.{8})/
   field :country, "Latvia"
   field :a2, "LV"

--- a/lib/phone/lv.ex
+++ b/lib/phone/lv.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LV do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(371)()(.{8})/
   field :country, "Latvia"
   field :a2, "LV"
   field :a3, "LVA"
-  match :regex
 end

--- a/lib/phone/ly.ex
+++ b/lib/phone/ly.ex
@@ -1,5 +1,6 @@
 defmodule Phone.LY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "218"
   field :regex, ~r/^(218)()(.+)/
   field :country, "Libya"
   field :a2, "LY"

--- a/lib/phone/ly.ex
+++ b/lib/phone/ly.ex
@@ -1,8 +1,7 @@
 defmodule Phone.LY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(218)()(.+)/
   field :country, "Libya"
   field :a2, "LY"
   field :a3, "LBY"
-  match :regex
 end

--- a/lib/phone/ma.ex
+++ b/lib/phone/ma.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "212"
   field :regex, ~r/^(212)()(.{9})/
   field :country, "Morocco"
   field :a2, "MA"

--- a/lib/phone/ma.ex
+++ b/lib/phone/ma.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(212)()(.{9})/
   field :country, "Morocco"
   field :a2, "MA"
   field :a3, "MAR"
-  match :regex
 end

--- a/lib/phone/mc.ex
+++ b/lib/phone/mc.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MC do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(377)()(.{9})/
   field :country, "Monaco"
   field :a2, "MC"
   field :a3, "MCO"
-  match :regex
 end

--- a/lib/phone/mc.ex
+++ b/lib/phone/mc.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MC do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "377"
   field :regex, ~r/^(377)()(.{9})/
   field :country, "Monaco"
   field :a2, "MC"

--- a/lib/phone/md.ex
+++ b/lib/phone/md.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MD do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "373"
   field :regex, ~r/^(373)()(.{8})/
   field :country, "Moldova"
   field :a2, "MD"

--- a/lib/phone/md.ex
+++ b/lib/phone/md.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MD do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(373)()(.{8})/
   field :country, "Moldova"
   field :a2, "MD"
   field :a3, "MDA"
-  match :regex
 end

--- a/lib/phone/me.ex
+++ b/lib/phone/me.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ME do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "382"
   field :regex, ~r/^(382)(..)(.{6})/
   field :country, "Montenegro"
   field :a2, "ME"

--- a/lib/phone/me.ex
+++ b/lib/phone/me.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ME do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(382)(..)(.{6})/
   field :country, "Montenegro"
   field :a2, "ME"
   field :a3, "MNE"
-  match :regex
 end

--- a/lib/phone/mg.ex
+++ b/lib/phone/mg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "261"
   field :regex, ~r/^(261)()(.+)/
   field :country, "Madagascar"
   field :a2, "MG"

--- a/lib/phone/mg.ex
+++ b/lib/phone/mg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(261)()(.+)/
   field :country, "Madagascar"
   field :a2, "MG"
   field :a3, "MDG"
-  match :regex
 end

--- a/lib/phone/mh.ex
+++ b/lib/phone/mh.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "692"
   field :regex, ~r/^(692)()(.{6,7})/
   field :country, "Marshall Islands"
   field :a2, "MH"

--- a/lib/phone/mh.ex
+++ b/lib/phone/mh.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(692)()(.{6,7})/
   field :country, "Marshall Islands"
   field :a2, "MH"
   field :a3, "MHL"
-  match :regex
 end

--- a/lib/phone/mk.ex
+++ b/lib/phone/mk.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(389)()(.{8})/
   field :country, "Macedonia"
   field :a2, "MK"
   field :a3, "MKD"
-  match :regex
 end

--- a/lib/phone/mk.ex
+++ b/lib/phone/mk.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "389"
   field :regex, ~r/^(389)()(.{8})/
   field :country, "Macedonia"
   field :a2, "MK"

--- a/lib/phone/ml.ex
+++ b/lib/phone/ml.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ML do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "223"
   field :regex, ~r/^(223)()(.{8})/
   field :country, "Mali"
   field :a2, "ML"

--- a/lib/phone/ml.ex
+++ b/lib/phone/ml.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ML do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(223)()(.{8})/
   field :country, "Mali"
   field :a2, "ML"
   field :a3, "MLI"
-  match :regex
 end

--- a/lib/phone/mm.ex
+++ b/lib/phone/mm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "95"
   field :regex, ~r/^(95)()(.{7,10})/
   field :country, "Myanmar"
   field :a2, "MM"

--- a/lib/phone/mm.ex
+++ b/lib/phone/mm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(95)()(.{7,10})/
   field :country, "Myanmar"
   field :a2, "MM"
   field :a3, "MMR"
-  match :regex
 end

--- a/lib/phone/mn.ex
+++ b/lib/phone/mn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "976"
   field :regex, ~r/^(976)()(.+)/
   field :country, "Mongolia"
   field :a2, "MN"

--- a/lib/phone/mn.ex
+++ b/lib/phone/mn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(976)()(.+)/
   field :country, "Mongolia"
   field :a2, "MN"
   field :a3, "MNG"
-  match :regex
 end

--- a/lib/phone/mo.ex
+++ b/lib/phone/mo.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(853)()(.{8})/
   field :country, "Macao"
   field :a2, "MO"
   field :a3, "MAC"
-  match :regex
 end

--- a/lib/phone/mo.ex
+++ b/lib/phone/mo.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "853"
   field :regex, ~r/^(853)()(.{8})/
   field :country, "Macao"
   field :a2, "MO"

--- a/lib/phone/mq.ex
+++ b/lib/phone/mq.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MQ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "596"
   field :regex, ~r/^(596)([5|6]96)(.{6})/
   field :country, "Martinique"
   field :a2, "MQ"

--- a/lib/phone/mq.ex
+++ b/lib/phone/mq.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MQ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(596)([5|6]96)(.{6})/
   field :country, "Martinique"
   field :a2, "MQ"
   field :a3, "MTQ"
-  match :regex
 end

--- a/lib/phone/mr.ex
+++ b/lib/phone/mr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "222"
   field :regex, ~r/^(222)()(.{8})/
   field :country, "Mauritania"
   field :a2, "MR"

--- a/lib/phone/mr.ex
+++ b/lib/phone/mr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(222)()(.{8})/
   field :country, "Mauritania"
   field :a2, "MR"
   field :a3, "MRT"
-  match :regex
 end

--- a/lib/phone/mt.ex
+++ b/lib/phone/mt.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "356"
   field :regex, ~r/^(356)()(.{8})/
   field :country, "Malta"
   field :a2, "MT"

--- a/lib/phone/mt.ex
+++ b/lib/phone/mt.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(356)()(.{8})/
   field :country, "Malta"
   field :a2, "MT"
   field :a3, "MLT"
-  match :regex
 end

--- a/lib/phone/mu.ex
+++ b/lib/phone/mu.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(230)()(.{8})/
   field :country, "Mauritius"
   field :a2, "MU"
   field :a3, "MUS"
-  match :regex
 end

--- a/lib/phone/mu.ex
+++ b/lib/phone/mu.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "230"
   field :regex, ~r/^(230)()(.{8})/
   field :country, "Mauritius"
   field :a2, "MU"

--- a/lib/phone/mv.ex
+++ b/lib/phone/mv.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MV do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "960"
   field :regex, ~r/^(960)()(.{7})/
   field :country, "Maldives"
   field :a2, "MV"

--- a/lib/phone/mv.ex
+++ b/lib/phone/mv.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MV do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(960)()(.{7})/
   field :country, "Maldives"
   field :a2, "MV"
   field :a3, "MDV"
-  match :regex
 end

--- a/lib/phone/mw.ex
+++ b/lib/phone/mw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(265)()(.{7,9})/
   field :country, "Malawi"
   field :a2, "MW"
   field :a3, "MWI"
-  match :regex
 end

--- a/lib/phone/mw.ex
+++ b/lib/phone/mw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "265"
   field :regex, ~r/^(265)()(.{7,9})/
   field :country, "Malawi"
   field :a2, "MW"

--- a/lib/phone/mx.ex
+++ b/lib/phone/mx.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MX do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "52"
   field :regex, ~r/^(52)()(.{10})/
   field :country, "Mexico"
   field :a2, "MX"

--- a/lib/phone/mx.ex
+++ b/lib/phone/mx.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MX do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(52)()(.{10})/
   field :country, "Mexico"
   field :a2, "MX"
   field :a3, "MEX"
-  match :regex
 end

--- a/lib/phone/my.ex
+++ b/lib/phone/my.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "60"
   field :regex, ~r/^(60)()(.+)/
   field :country, "Malaysia"
   field :a2, "MY"

--- a/lib/phone/my.ex
+++ b/lib/phone/my.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(60)()(.+)/
   field :country, "Malaysia"
   field :a2, "MY"
   field :a3, "MYS"
-  match :regex
 end

--- a/lib/phone/mz.ex
+++ b/lib/phone/mz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.MZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(258)()(.+)/
   field :country, "Mozambique"
   field :a2, "MZ"
   field :a3, "MOZ"
-  match :regex
 end

--- a/lib/phone/mz.ex
+++ b/lib/phone/mz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.MZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "258"
   field :regex, ~r/^(258)()(.+)/
   field :country, "Mozambique"
   field :a2, "MZ"

--- a/lib/phone/na.ex
+++ b/lib/phone/na.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "264"
   field :regex, ~r/^(264)()(.+)/
   field :country, "Namibia"
   field :a2, "NA"

--- a/lib/phone/na.ex
+++ b/lib/phone/na.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(264)()(.+)/
   field :country, "Namibia"
   field :a2, "NA"
   field :a3, "NAM"
-  match :regex
 end

--- a/lib/phone/nanp.ex
+++ b/lib/phone/nanp.ex
@@ -1,5 +1,5 @@
 defmodule Phone.NANP do
-  use Helper.Country
+  use Helper.Country, match: :modules
   field :modules, [
     Phone.NANP.AS,
     Phone.NANP.AI,
@@ -28,5 +28,4 @@ defmodule Phone.NANP do
     Phone.NANP.VI,
     Phone.NANP.TollFree
   ]
-  match :modules
 end

--- a/lib/phone/nanp/ag.ex
+++ b/lib/phone/nanp/ag.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.AG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(268)([2-9].{6})$/
   field :country, "Antigua and Barbuda"
   field :a2, "AG"

--- a/lib/phone/nanp/ag.ex
+++ b/lib/phone/nanp/ag.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.AG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(268)([2-9].{6})$/
   field :country, "Antigua and Barbuda"
   field :a2, "AG"
   field :a3, "ATG"
-  match :regex
 end

--- a/lib/phone/nanp/ai.ex
+++ b/lib/phone/nanp/ai.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.AI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(264)([2-9].{6})$/
   field :country, "Anguilla"
   field :a2, "AI"

--- a/lib/phone/nanp/ai.ex
+++ b/lib/phone/nanp/ai.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.AI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(264)([2-9].{6})$/
   field :country, "Anguilla"
   field :a2, "AI"
   field :a3, "AIA"
-  match :regex
 end

--- a/lib/phone/nanp/as.ex
+++ b/lib/phone/nanp/as.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.AS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(684)([2-9].{6})$/
   field :country, "American Samoa"
   field :a2, "AS"

--- a/lib/phone/nanp/as.ex
+++ b/lib/phone/nanp/as.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.AS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(684)([2-9].{6})$/
   field :country, "American Samoa"
   field :a2, "AS"
   field :a3, "ASM"
-  match :regex
 end

--- a/lib/phone/nanp/bb.ex
+++ b/lib/phone/nanp/bb.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.BB do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(246)([2-9].{6})$/
   field :country, "Barbados"
   field :a2, "BB"

--- a/lib/phone/nanp/bb.ex
+++ b/lib/phone/nanp/bb.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.BB do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(246)([2-9].{6})$/
   field :country, "Barbados"
   field :a2, "BB"
   field :a3, "BRB"
-  match :regex
 end

--- a/lib/phone/nanp/bm.ex
+++ b/lib/phone/nanp/bm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.BM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(441)([2-9].{6})$/
   field :country, "Bermuda"
   field :a2, "BM"

--- a/lib/phone/nanp/bm.ex
+++ b/lib/phone/nanp/bm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.BM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(441)([2-9].{6})$/
   field :country, "Bermuda"
   field :a2, "BM"
   field :a3, "BMU"
-  match :regex
 end

--- a/lib/phone/nanp/bs.ex
+++ b/lib/phone/nanp/bs.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.BS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(242)([2-9].{6})$/
   field :country, "Bahamas"
   field :a2, "BS"

--- a/lib/phone/nanp/bs.ex
+++ b/lib/phone/nanp/bs.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.BS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(242)([2-9].{6})$/
   field :country, "Bahamas"
   field :a2, "BS"
   field :a3, "BHS"
-  match :regex
 end

--- a/lib/phone/nanp/ca.ex
+++ b/lib/phone/nanp/ca.ex
@@ -1,5 +1,5 @@
 defmodule Phone.NANP.CA do
-  use Helper.Country
+  use Helper.Country, match: :modules
   field :country, "Canada"
   field :a2, "CA"
   field :a3, "CAN"
@@ -15,5 +15,4 @@ defmodule Phone.NANP.CA do
     Phone.NANP.CA.SK,
     Phone.NANP.CA.Territory
   ]
-  match :modules
 end

--- a/lib/phone/nanp/dm.ex
+++ b/lib/phone/nanp/dm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.DM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(767)([2-9].{6})$/
   field :country, "Dominica"
   field :a2, "DM"

--- a/lib/phone/nanp/dm.ex
+++ b/lib/phone/nanp/dm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.DM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(767)([2-9].{6})$/
   field :country, "Dominica"
   field :a2, "DM"
   field :a3, "DMA"
-  match :regex
 end

--- a/lib/phone/nanp/do.ex
+++ b/lib/phone/nanp/do.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.DO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(8[0|2|4]9)([2-9].{6})$/
   field :country, "Dominican Republic"
   field :a2, "DO"

--- a/lib/phone/nanp/do.ex
+++ b/lib/phone/nanp/do.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.DO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(8[0|2|4]9)([2-9].{6})$/
   field :country, "Dominican Republic"
   field :a2, "DO"
   field :a3, "DOM"
-  match :regex
 end

--- a/lib/phone/nanp/gd.ex
+++ b/lib/phone/nanp/gd.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.GD do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(473)([2-9].{6})$/
   field :country, "Grenada"
   field :a2, "GD"

--- a/lib/phone/nanp/gd.ex
+++ b/lib/phone/nanp/gd.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.GD do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(473)([2-9].{6})$/
   field :country, "Grenada"
   field :a2, "GD"
   field :a3, "GRD"
-  match :regex
 end

--- a/lib/phone/nanp/gu.ex
+++ b/lib/phone/nanp/gu.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.GU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(671)([2-9].{6})$/
   field :country, "Guam"
   field :a2, "GU"
   field :a3, "GUM"
-  match :regex
 end

--- a/lib/phone/nanp/gu.ex
+++ b/lib/phone/nanp/gu.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.GU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(671)([2-9].{6})$/
   field :country, "Guam"
   field :a2, "GU"

--- a/lib/phone/nanp/jm.ex
+++ b/lib/phone/nanp/jm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.JM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(876)([2-9].{6})$/
   field :country, "Jamaica"
   field :a2, "JA"
   field :a3, "JAM"
-  match :regex
 end

--- a/lib/phone/nanp/jm.ex
+++ b/lib/phone/nanp/jm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.JM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(876)([2-9].{6})$/
   field :country, "Jamaica"
   field :a2, "JA"

--- a/lib/phone/nanp/kn.ex
+++ b/lib/phone/nanp/kn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.KN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(869)([2-9].{6})$/
   field :country, "Saint Kitts and Nevis"
   field :a2, "KN"

--- a/lib/phone/nanp/kn.ex
+++ b/lib/phone/nanp/kn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.KN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(869)([2-9].{6})$/
   field :country, "Saint Kitts and Nevis"
   field :a2, "KN"
   field :a3, "KNA"
-  match :regex
 end

--- a/lib/phone/nanp/ky.ex
+++ b/lib/phone/nanp/ky.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.KY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(345)([2-9].{6})$/
   field :country, "Cayman Islands"
   field :a2, "KY"

--- a/lib/phone/nanp/ky.ex
+++ b/lib/phone/nanp/ky.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.KY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(345)([2-9].{6})$/
   field :country, "Cayman Islands"
   field :a2, "KY"
   field :a3, "CYM"
-  match :regex
 end

--- a/lib/phone/nanp/lc.ex
+++ b/lib/phone/nanp/lc.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.LC do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(758)([2-9].{6})$/
   field :country, "Saint Lucia"
   field :a2, "LC"
   field :a3, "LCA"
-  match :regex
 end

--- a/lib/phone/nanp/lc.ex
+++ b/lib/phone/nanp/lc.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.LC do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(758)([2-9].{6})$/
   field :country, "Saint Lucia"
   field :a2, "LC"

--- a/lib/phone/nanp/mp.ex
+++ b/lib/phone/nanp/mp.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.MP do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(670)([2-9].{6})$/
   field :country, "Northern Mariana Islands"
   field :a2, "MP"
   field :a3, "MNP"
-  match :regex
 end

--- a/lib/phone/nanp/mp.ex
+++ b/lib/phone/nanp/mp.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.MP do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(670)([2-9].{6})$/
   field :country, "Northern Mariana Islands"
   field :a2, "MP"

--- a/lib/phone/nanp/ms.ex
+++ b/lib/phone/nanp/ms.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.MS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(664)([2-9].{6})$/
   field :country, "Montserrat"
   field :a2, "MS"

--- a/lib/phone/nanp/ms.ex
+++ b/lib/phone/nanp/ms.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.MS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(664)([2-9].{6})$/
   field :country, "Montserrat"
   field :a2, "MS"
   field :a3, "MSR"
-  match :regex
 end

--- a/lib/phone/nanp/pr.ex
+++ b/lib/phone/nanp/pr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.PR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(787|939)([2-9].{6})$/
   field :country, "Puerto Rico"
   field :a2, "PR"
   field :a3, "PRI"
-  match :regex
 end

--- a/lib/phone/nanp/pr.ex
+++ b/lib/phone/nanp/pr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.PR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(787|939)([2-9].{6})$/
   field :country, "Puerto Rico"
   field :a2, "PR"

--- a/lib/phone/nanp/sx.ex
+++ b/lib/phone/nanp/sx.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.SX do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(721)([2-9].{6})$/
   field :country, "Sint Maarten"
   field :a2, "SX"
   field :a3, "SXM"
-  match :regex
 end

--- a/lib/phone/nanp/sx.ex
+++ b/lib/phone/nanp/sx.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.SX do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(721)([2-9].{6})$/
   field :country, "Sint Maarten"
   field :a2, "SX"

--- a/lib/phone/nanp/tc.ex
+++ b/lib/phone/nanp/tc.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.TC do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(649)([2-9].{6})$/
   field :country, "Turks and Caicos Islands"
   field :a2, "TC"
   field :a3, "TCA"
-  match :regex
 end

--- a/lib/phone/nanp/tc.ex
+++ b/lib/phone/nanp/tc.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.TC do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(649)([2-9].{6})$/
   field :country, "Turks and Caicos Islands"
   field :a2, "TC"

--- a/lib/phone/nanp/toll_free.ex
+++ b/lib/phone/nanp/toll_free.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.TollFree do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(800|844|855|866|877|888)([2-9].{6})$/
   field :country, "NANP tool-free"
   field :a2, ""

--- a/lib/phone/nanp/toll_free.ex
+++ b/lib/phone/nanp/toll_free.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.TollFree do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(800|844|855|866|877|888)([2-9].{6})$/
   field :country, "NANP tool-free"
   field :a2, ""
   field :a3, ""
-  match :regex
 end

--- a/lib/phone/nanp/tt.ex
+++ b/lib/phone/nanp/tt.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.TT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(868)([2-9].{6})$/
   field :country, "Trinidad and Tobago"
   field :a2, "TT"
   field :a3, "TTO"
-  match :regex
 end

--- a/lib/phone/nanp/tt.ex
+++ b/lib/phone/nanp/tt.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.TT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(868)([2-9].{6})$/
   field :country, "Trinidad and Tobago"
   field :a2, "TT"

--- a/lib/phone/nanp/us.ex
+++ b/lib/phone/nanp/us.ex
@@ -1,5 +1,5 @@
 defmodule Phone.NANP.US do
-  use Helper.Country
+  use Helper.Country, match: :modules
   field :country, "United States"
   field :a2, "US"
   field :a3, "USA"
@@ -56,5 +56,4 @@ defmodule Phone.NANP.US do
     Phone.NANP.US.WV,
     Phone.NANP.US.WY
   ]
-  match :modules
 end

--- a/lib/phone/nanp/vc.ex
+++ b/lib/phone/nanp/vc.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.VC do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(784)([2-9].{6})$/
   field :country, "Saint Vicent and the Grenadines"
   field :a2, "VC"
   field :a3, "VCT"
-  match :regex
 end

--- a/lib/phone/nanp/vc.ex
+++ b/lib/phone/nanp/vc.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.VC do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(784)([2-9].{6})$/
   field :country, "Saint Vicent and the Grenadines"
   field :a2, "VC"

--- a/lib/phone/nanp/vg.ex
+++ b/lib/phone/nanp/vg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.VG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(284)([2-9].{6})$/
   field :country, "British Virgin Islands"
   field :a2, "VG"
   field :a3, "VGB"
-  match :regex
 end

--- a/lib/phone/nanp/vg.ex
+++ b/lib/phone/nanp/vg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.VG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(284)([2-9].{6})$/
   field :country, "British Virgin Islands"
   field :a2, "VG"

--- a/lib/phone/nanp/vi.ex
+++ b/lib/phone/nanp/vi.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NANP.VI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "1"
   field :regex, ~r/^(1)(340)([2-9].{6})$/
   field :country, "US Virgin Islands"
   field :a2, "VI"

--- a/lib/phone/nanp/vi.ex
+++ b/lib/phone/nanp/vi.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NANP.VI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(1)(340)([2-9].{6})$/
   field :country, "US Virgin Islands"
   field :a2, "VI"
   field :a3, "VIR"
-  match :regex
 end

--- a/lib/phone/nc.ex
+++ b/lib/phone/nc.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NC do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(687)()(.{6})/
   field :country, "New Caledonia"
   field :a2, "NC"
   field :a3, "NCL"
-  match :regex
 end

--- a/lib/phone/nc.ex
+++ b/lib/phone/nc.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NC do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "687"
   field :regex, ~r/^(687)()(.{6})/
   field :country, "New Caledonia"
   field :a2, "NC"

--- a/lib/phone/ne.ex
+++ b/lib/phone/ne.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "227"
   field :regex, ~r/^(227)()(.{8})/
   field :country, "Niger"
   field :a2, "NE"

--- a/lib/phone/ne.ex
+++ b/lib/phone/ne.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(227)()(.{8})/
   field :country, "Niger"
   field :a2, "NE"
   field :a3, "NER"
-  match :regex
 end

--- a/lib/phone/ng.ex
+++ b/lib/phone/ng.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(234)()(.+)/
   field :country, "Nigeria"
   field :a2, "NG"
   field :a3, "NGA"
-  match :regex
 end

--- a/lib/phone/ng.ex
+++ b/lib/phone/ng.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "234"
   field :regex, ~r/^(234)()(.+)/
   field :country, "Nigeria"
   field :a2, "NG"

--- a/lib/phone/ni.ex
+++ b/lib/phone/ni.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(505)()(.{8})/
   field :country, "Nicaragua"
   field :a2, "NI"
   field :a3, "NIC"
-  match :regex
 end

--- a/lib/phone/ni.ex
+++ b/lib/phone/ni.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "505"
   field :regex, ~r/^(505)()(.{8})/
   field :country, "Nicaragua"
   field :a2, "NI"

--- a/lib/phone/nl.ex
+++ b/lib/phone/nl.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(31)()(.{9})/
   field :country, "Netherlands"
   field :a2, "NL"
   field :a3, "NLD"
-  match :regex
 end

--- a/lib/phone/nl.ex
+++ b/lib/phone/nl.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "31"
   field :regex, ~r/^(31)()(.{9})/
   field :country, "Netherlands"
   field :a2, "NL"

--- a/lib/phone/no.ex
+++ b/lib/phone/no.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "47"
   field :regex, ~r/^(47)()([2-8].{7}|0.{3})/
   field :country, "Norway"
   field :a2, "NO"

--- a/lib/phone/no.ex
+++ b/lib/phone/no.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(47)()([2-8].{7}|0.{3})/
   field :country, "Norway"
   field :a2, "NO"
   field :a3, "NOR"
-  match :regex
 end

--- a/lib/phone/np.ex
+++ b/lib/phone/np.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NP do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(977)()(.{8})/
   field :country, "Nepal"
   field :a2, "NP"
   field :a3, "NPL"
-  match :regex
 end

--- a/lib/phone/np.ex
+++ b/lib/phone/np.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NP do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "977"
   field :regex, ~r/^(977)()(.{8})/
   field :country, "Nepal"
   field :a2, "NP"

--- a/lib/phone/nr.ex
+++ b/lib/phone/nr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "674"
   field :regex, ~r/^(674)()(.{7})/
   field :country, "Nauru"
   field :a2, "NR"

--- a/lib/phone/nr.ex
+++ b/lib/phone/nr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(674)()(.{7})/
   field :country, "Nauru"
   field :a2, "NR"
   field :a3, "NRU"
-  match :regex
 end

--- a/lib/phone/nu.ex
+++ b/lib/phone/nu.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(683)()(.{4})/
   field :country, "Niue"
   field :a2, "NU"
   field :a3, "NIU"
-  match :regex
 end

--- a/lib/phone/nu.ex
+++ b/lib/phone/nu.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "683"
   field :regex, ~r/^(683)()(.{4})/
   field :country, "Niue"
   field :a2, "NU"

--- a/lib/phone/nz.ex
+++ b/lib/phone/nz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.NZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "64"
   field :regex, ~r/^(64)()(.+)/
   field :country, "New Zealand"
   field :a2, "NZ"

--- a/lib/phone/nz.ex
+++ b/lib/phone/nz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.NZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(64)()(.+)/
   field :country, "New Zealand"
   field :a2, "NZ"
   field :a3, "NZL"
-  match :regex
 end

--- a/lib/phone/om.ex
+++ b/lib/phone/om.ex
@@ -1,8 +1,7 @@
 defmodule Phone.OM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(968)()(.{8})/
   field :country, "Oman"
   field :a2, "OM"
   field :a3, "OMN"
-  match :regex
 end

--- a/lib/phone/om.ex
+++ b/lib/phone/om.ex
@@ -1,5 +1,6 @@
 defmodule Phone.OM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "968"
   field :regex, ~r/^(968)()(.{8})/
   field :country, "Oman"
   field :a2, "OM"

--- a/lib/phone/pa.ex
+++ b/lib/phone/pa.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(507)()(.{7})/
   field :country, "Panama"
   field :a2, "PA"
   field :a3, "PAN"
-  match :regex
 end

--- a/lib/phone/pa.ex
+++ b/lib/phone/pa.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "507"
   field :regex, ~r/^(507)()(.{7})/
   field :country, "Panama"
   field :a2, "PA"

--- a/lib/phone/pe.ex
+++ b/lib/phone/pe.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "51"
   field :regex, ~r/^(51)()(.{8,9})/
   field :country, "Peru"
   field :a2, "PE"

--- a/lib/phone/pe.ex
+++ b/lib/phone/pe.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(51)()(.{8,9})/
   field :country, "Peru"
   field :a2, "PE"
   field :a3, "PER"
-  match :regex
 end

--- a/lib/phone/pf.ex
+++ b/lib/phone/pf.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PF do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "689"
   field :regex, ~r/^(689)()(.{8})/
   field :country, "French Polynesia"
   field :a2, "PF"

--- a/lib/phone/pf.ex
+++ b/lib/phone/pf.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PF do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(689)()(.{8})/
   field :country, "French Polynesia"
   field :a2, "PF"
   field :a3, "PYF"
-  match :regex
 end

--- a/lib/phone/pg.ex
+++ b/lib/phone/pg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(675)()(.+)/
   field :country, "Papua New Guinea"
   field :a2, "PG"
   field :a3, "PNG"
-  match :regex
 end

--- a/lib/phone/pg.ex
+++ b/lib/phone/pg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "675"
   field :regex, ~r/^(675)()(.+)/
   field :country, "Papua New Guinea"
   field :a2, "PG"

--- a/lib/phone/ph.ex
+++ b/lib/phone/ph.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(63)()(.+)/
   field :country, "Philippines"
   field :a2, "PH"
   field :a3, "PHL"
-  match :regex
 end

--- a/lib/phone/ph.ex
+++ b/lib/phone/ph.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "63"
   field :regex, ~r/^(63)()(.+)/
   field :country, "Philippines"
   field :a2, "PH"

--- a/lib/phone/pk.ex
+++ b/lib/phone/pk.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(92)()(.+'')/
   field :country, "Pakistan"
   field :a2, "PK"
   field :a3, "PAK"
-  match :regex
 end

--- a/lib/phone/pk.ex
+++ b/lib/phone/pk.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "92"
   field :regex, ~r/^(92)()(.+'')/
   field :country, "Pakistan"
   field :a2, "PK"

--- a/lib/phone/pl.ex
+++ b/lib/phone/pl.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(48)()(.+)/
   field :country, "Poland"
   field :a2, "PL"
   field :a3, "POL"
-  match :regex
 end

--- a/lib/phone/pl.ex
+++ b/lib/phone/pl.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "48"
   field :regex, ~r/^(48)()(.+)/
   field :country, "Poland"
   field :a2, "PL"

--- a/lib/phone/pm.ex
+++ b/lib/phone/pm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "508"
   field :regex, ~r/^(508)()(.{6})/
   field :country, "Saint Pierre and Miquelon"
   field :a2, "PM"

--- a/lib/phone/pm.ex
+++ b/lib/phone/pm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(508)()(.{6})/
   field :country, "Saint Pierre and Miquelon"
   field :a2, "PM"
   field :a3, "SPM"
-  match :regex
 end

--- a/lib/phone/ps.ex
+++ b/lib/phone/ps.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "970"
   field :regex, ~r/^(970)()(.{8,9})/
   field :country, "Palestine"
   field :a2, "DJ"

--- a/lib/phone/ps.ex
+++ b/lib/phone/ps.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(970)()(.{8,9})/
   field :country, "Palestine"
   field :a2, "DJ"
   field :a3, "DJI"
-  match :regex
 end

--- a/lib/phone/pt.ex
+++ b/lib/phone/pt.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PT do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(351)()(.{9})/
   field :country, "Portugal"
   field :a2, "PT"
   field :a3, "PRT"
-  match :regex
 end

--- a/lib/phone/pt.ex
+++ b/lib/phone/pt.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PT do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "351"
   field :regex, ~r/^(351)()(.{9})/
   field :country, "Portugal"
   field :a2, "PT"

--- a/lib/phone/pw.ex
+++ b/lib/phone/pw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(680)()(.{7})/
   field :country, "Palau"
   field :a2, "PW"
   field :a3, "PLW"
-  match :regex
 end

--- a/lib/phone/pw.ex
+++ b/lib/phone/pw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "680"
   field :regex, ~r/^(680)()(.{7})/
   field :country, "Palau"
   field :a2, "PW"

--- a/lib/phone/py.ex
+++ b/lib/phone/py.ex
@@ -1,5 +1,6 @@
 defmodule Phone.PY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "595"
   field :regex, ~r/^(595)()(.+)/
   field :country, "Paraguay"
   field :a2, "PY"

--- a/lib/phone/py.ex
+++ b/lib/phone/py.ex
@@ -1,8 +1,7 @@
 defmodule Phone.PY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(595)()(.+)/
   field :country, "Paraguay"
   field :a2, "PY"
   field :a3, "PRY"
-  match :regex
 end

--- a/lib/phone/qa.ex
+++ b/lib/phone/qa.ex
@@ -1,8 +1,7 @@
 defmodule Phone.QA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(974)()(.{8})/
   field :country, "Qatar"
   field :a2, "QA"
   field :a3, "QAT"
-  match :regex
 end

--- a/lib/phone/qa.ex
+++ b/lib/phone/qa.ex
@@ -1,5 +1,6 @@
 defmodule Phone.QA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "974"
   field :regex, ~r/^(974)()(.{8})/
   field :country, "Qatar"
   field :a2, "QA"

--- a/lib/phone/ro.ex
+++ b/lib/phone/ro.ex
@@ -1,5 +1,6 @@
 defmodule Phone.RO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "40"
   field :regex, ~r/^(40)()(.{9})/
   field :country, "Romania"
   field :a2, "RO"

--- a/lib/phone/ro.ex
+++ b/lib/phone/ro.ex
@@ -1,8 +1,7 @@
 defmodule Phone.RO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(40)()(.{9})/
   field :country, "Romania"
   field :a2, "RO"
   field :a3, "ROU"
-  match :regex
 end

--- a/lib/phone/rs.ex
+++ b/lib/phone/rs.ex
@@ -1,5 +1,6 @@
 defmodule Phone.RS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "381"
   field :regex, ~r/^(381)()(.+)/
   field :country, "Serbia"
   field :a2, "RS"

--- a/lib/phone/rs.ex
+++ b/lib/phone/rs.ex
@@ -1,8 +1,7 @@
 defmodule Phone.RS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(381)()(.+)/
   field :country, "Serbia"
   field :a2, "RS"
   field :a3, "SRB"
-  match :regex
 end

--- a/lib/phone/ru.ex
+++ b/lib/phone/ru.ex
@@ -1,8 +1,7 @@
 defmodule Phone.RU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(7)([3-589]..)(.{7})/
   field :country, "Russia"
   field :a2, "RU"
   field :a3, "RUS"
-  match :regex
 end

--- a/lib/phone/ru.ex
+++ b/lib/phone/ru.ex
@@ -1,5 +1,6 @@
 defmodule Phone.RU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "7"
   field :regex, ~r/^(7)([3-589]..)(.{7})/
   field :country, "Russia"
   field :a2, "RU"

--- a/lib/phone/rw.ex
+++ b/lib/phone/rw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.RW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "250"
   field :regex, ~r/^(250)()(.{9})/
   field :country, "Rwanda"
   field :a2, "RW"

--- a/lib/phone/rw.ex
+++ b/lib/phone/rw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.RW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(250)()(.{9})/
   field :country, "Rwanda"
   field :a2, "RW"
   field :a3, "RWA"
-  match :regex
 end

--- a/lib/phone/sa.ex
+++ b/lib/phone/sa.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "966"
   field :regex, ~r/^(966)()(.+)/
   field :country, "Saudi Arabia"
   field :a2, "SA"

--- a/lib/phone/sa.ex
+++ b/lib/phone/sa.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(966)()(.+)/
   field :country, "Saudi Arabia"
   field :a2, "SA"
   field :a3, "SAU"
-  match :regex
 end

--- a/lib/phone/sb.ex
+++ b/lib/phone/sb.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SB do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "677"
   field :regex, ~r/^(677)()(.+)/
   field :country, "Solomon Islands"
   field :a2, "SB"

--- a/lib/phone/sb.ex
+++ b/lib/phone/sb.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SB do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(677)()(.+)/
   field :country, "Solomon Islands"
   field :a2, "SB"
   field :a3, "SLB"
-  match :regex
 end

--- a/lib/phone/sc.ex
+++ b/lib/phone/sc.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SC do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "248"
   field :regex, ~r/^(248)()(.{7})/
   field :country, "Seychelles"
   field :a2, "SC"

--- a/lib/phone/sc.ex
+++ b/lib/phone/sc.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SC do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(248)()(.{7})/
   field :country, "Seychelles"
   field :a2, "SC"
   field :a3, "SYC"
-  match :regex
 end

--- a/lib/phone/sd.ex
+++ b/lib/phone/sd.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SD do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(249)()(.+)/
   field :country, "Sudan"
   field :a2, "SD"
   field :a3, "SDN"
-  match :regex
 end

--- a/lib/phone/sd.ex
+++ b/lib/phone/sd.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SD do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "249"
   field :regex, ~r/^(249)()(.+)/
   field :country, "Sudan"
   field :a2, "SD"

--- a/lib/phone/se.ex
+++ b/lib/phone/se.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(46)()(.+)/
   field :country, "Sweden"
   field :a2, "SE"
   field :a3, "SWE"
-  match :regex
 end

--- a/lib/phone/se.ex
+++ b/lib/phone/se.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "46"
   field :regex, ~r/^(46)()(.+)/
   field :country, "Sweden"
   field :a2, "SE"

--- a/lib/phone/sg.ex
+++ b/lib/phone/sg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "65"
   field :regex, ~r/^(65)()(.{8})/
   field :country, "Singapore"
   field :a2, "SG"

--- a/lib/phone/sg.ex
+++ b/lib/phone/sg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(65)()(.{8})/
   field :country, "Singapore"
   field :a2, "SG"
   field :a3, "SGP"
-  match :regex
 end

--- a/lib/phone/sh.ex
+++ b/lib/phone/sh.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "290"
   field :regex, ~r/^(290)()(.{5})/
   field :country, "Saint Helena and Tristan da Cunha"
   field :a2, "SH"

--- a/lib/phone/sh.ex
+++ b/lib/phone/sh.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(290)()(.{5})/
   field :country, "Saint Helena and Tristan da Cunha"
   field :a2, "SH"
   field :a3, "SHN"
-  match :regex
 end

--- a/lib/phone/si.ex
+++ b/lib/phone/si.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SI do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(386)()(.+)/
   field :country, "Slovenia"
   field :a2, "SI"
   field :a3, "SVN"
-  match :regex
 end

--- a/lib/phone/si.ex
+++ b/lib/phone/si.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SI do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "386"
   field :regex, ~r/^(386)()(.+)/
   field :country, "Slovenia"
   field :a2, "SI"

--- a/lib/phone/sk.ex
+++ b/lib/phone/sk.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(421)()(.+)/
   field :country, "Slovakia"
   field :a2, "SK"
   field :a3, "SVK"
-  match :regex
 end

--- a/lib/phone/sk.ex
+++ b/lib/phone/sk.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "421"
   field :regex, ~r/^(421)()(.+)/
   field :country, "Slovakia"
   field :a2, "SK"

--- a/lib/phone/sl.ex
+++ b/lib/phone/sl.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(232)(..)(.{6})/
   field :country, "Sierra Leone"
   field :a2, "SL"
   field :a3, "SLE"
-  match :regex
 end

--- a/lib/phone/sl.ex
+++ b/lib/phone/sl.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "232"
   field :regex, ~r/^(232)(..)(.{6})/
   field :country, "Sierra Leone"
   field :a2, "SL"

--- a/lib/phone/sm.ex
+++ b/lib/phone/sm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(378)(0549)(.{6})/
   field :country, "San Marino"
   field :a2, "SM"
   field :a3, "SMR"
-  match :regex
 end

--- a/lib/phone/sm.ex
+++ b/lib/phone/sm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "378"
   field :regex, ~r/^(378)(0549)(.{6})/
   field :country, "San Marino"
   field :a2, "SM"

--- a/lib/phone/sn.ex
+++ b/lib/phone/sn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(221)()(.{7})/
   field :country, "Senegal"
   field :a2, "SN"
   field :a3, "SEN"
-  match :regex
 end

--- a/lib/phone/sn.ex
+++ b/lib/phone/sn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "221"
   field :regex, ~r/^(221)()(.{7})/
   field :country, "Senegal"
   field :a2, "SN"

--- a/lib/phone/so.ex
+++ b/lib/phone/so.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(252)()(.+)/
   field :country, "Somalia"
   field :a2, "SO"
   field :a3, "SOM"
-  match :regex
 end

--- a/lib/phone/so.ex
+++ b/lib/phone/so.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "252"
   field :regex, ~r/^(252)()(.+)/
   field :country, "Somalia"
   field :a2, "SO"

--- a/lib/phone/sr.ex
+++ b/lib/phone/sr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "597"
   field :regex, ~r/^(597)()(.{6,7})/
   field :country, "Suriname"
   field :a2, "SR"

--- a/lib/phone/sr.ex
+++ b/lib/phone/sr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(597)()(.{6,7})/
   field :country, "Suriname"
   field :a2, "SR"
   field :a3, "SUR"
-  match :regex
 end

--- a/lib/phone/ss.ex
+++ b/lib/phone/ss.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(211)()(.+)/
   field :country, "South Sudan"
   field :a2, "SS"
   field :a3, "SSD"
-  match :regex
 end

--- a/lib/phone/ss.ex
+++ b/lib/phone/ss.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "211"
   field :regex, ~r/^(211)()(.+)/
   field :country, "South Sudan"
   field :a2, "SS"

--- a/lib/phone/st.ex
+++ b/lib/phone/st.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ST do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "239"
   field :regex, ~r/^(239)()(.{7})/
   field :country, "Sao Tome and Principe"
   field :a2, "ST"

--- a/lib/phone/st.ex
+++ b/lib/phone/st.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ST do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(239)()(.{7})/
   field :country, "Sao Tome and Principe"
   field :a2, "ST"
   field :a3, "STP"
-  match :regex
 end

--- a/lib/phone/sv.ex
+++ b/lib/phone/sv.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SV do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(503)()(.{7,8})/
   field :country, "El Salvador"
   field :a2, "SV"
   field :a3, "SLV"
-  match :regex
 end

--- a/lib/phone/sv.ex
+++ b/lib/phone/sv.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SV do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "503"
   field :regex, ~r/^(503)()(.{7,8})/
   field :country, "El Salvador"
   field :a2, "SV"

--- a/lib/phone/sy.ex
+++ b/lib/phone/sy.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "963"
   field :regex, ~r/^(963)()(.+)/
   field :country, "Syria"
   field :a2, "SY"

--- a/lib/phone/sy.ex
+++ b/lib/phone/sy.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(963)()(.+)/
   field :country, "Syria"
   field :a2, "SY"
   field :a3, "SYR"
-  match :regex
 end

--- a/lib/phone/sz.ex
+++ b/lib/phone/sz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.SZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "268"
   field :regex, ~r/^(268)()(.{8})/
   field :country, "Swaziland"
   field :a2, "SZ"

--- a/lib/phone/sz.ex
+++ b/lib/phone/sz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.SZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(268)()(.{8})/
   field :country, "Swaziland"
   field :a2, "SZ"
   field :a3, "SWZ"
-  match :regex
 end

--- a/lib/phone/td.ex
+++ b/lib/phone/td.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TD do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "235"
   field :regex, ~r/^(235)()(.{8})/
   field :country, "Chad"
   field :a2, "TD"

--- a/lib/phone/td.ex
+++ b/lib/phone/td.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TD do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(235)()(.{8})/
   field :country, "Chad"
   field :a2, "TD"
   field :a3, "TCD"
-  match :regex
 end

--- a/lib/phone/tg.ex
+++ b/lib/phone/tg.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "228"
   field :regex, ~r/^(228)()(.{8})/
   field :country, "Togo"
   field :a2, "TG"

--- a/lib/phone/tg.ex
+++ b/lib/phone/tg.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(228)()(.{8})/
   field :country, "Togo"
   field :a2, "TG"
   field :a3, "TGO"
-  match :regex
 end

--- a/lib/phone/th.ex
+++ b/lib/phone/th.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TH do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "66"
   field :regex, ~r/^(66)()(.+)/
   field :country, "Thailand"
   field :a2, "TH"

--- a/lib/phone/th.ex
+++ b/lib/phone/th.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TH do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(66)()(.+)/
   field :country, "Thailand"
   field :a2, "TH"
   field :a3, "THA"
-  match :regex
 end

--- a/lib/phone/tj.ex
+++ b/lib/phone/tj.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TJ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(992)()(.{9})/
   field :country, "Tajikistan"
   field :a2, "TJ"
   field :a3, "TJK"
-  match :regex
 end

--- a/lib/phone/tj.ex
+++ b/lib/phone/tj.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TJ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "992"
   field :regex, ~r/^(992)()(.{9})/
   field :country, "Tajikistan"
   field :a2, "TJ"

--- a/lib/phone/tk.ex
+++ b/lib/phone/tk.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TK do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "690"
   field :regex, ~r/^(690)([1-9])(.{3})/
   field :country, "Tokelau"
   field :a2, "TK"

--- a/lib/phone/tk.ex
+++ b/lib/phone/tk.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TK do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(690)([1-9])(.{3})/
   field :country, "Tokelau"
   field :a2, "TK"
   field :a3, "TKL"
-  match :regex
 end

--- a/lib/phone/tl.ex
+++ b/lib/phone/tl.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TL do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "670"
   field :regex, ~r/^(670)()(.{8})/
   field :country, "East Timor"
   field :a2, "TL"

--- a/lib/phone/tl.ex
+++ b/lib/phone/tl.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TL do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(670)()(.{8})/
   field :country, "East Timor"
   field :a2, "TL"
   field :a3, "TLS"
-  match :regex
 end

--- a/lib/phone/tm.ex
+++ b/lib/phone/tm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "993"
   field :regex, ~r/^(993)()(.+)/
   field :country, "Turkmenistan"
   field :a2, "TM"

--- a/lib/phone/tm.ex
+++ b/lib/phone/tm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(993)()(.+)/
   field :country, "Turkmenistan"
   field :a2, "TM"
   field :a3, "TKM"
-  match :regex
 end

--- a/lib/phone/tn.ex
+++ b/lib/phone/tn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "216"
   field :regex, ~r/^(216)()(.{8})/
   field :country, "Tunisia"
   field :a2, "TN"

--- a/lib/phone/tn.ex
+++ b/lib/phone/tn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(216)()(.{8})/
   field :country, "Tunisia"
   field :a2, "TN"
   field :a3, "TUN"
-  match :regex
 end

--- a/lib/phone/to.ex
+++ b/lib/phone/to.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TO do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "676"
   field :regex, ~r/^(676)()(.+)/
   field :country, "Tonga"
   field :a2, "TO"

--- a/lib/phone/to.ex
+++ b/lib/phone/to.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TO do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(676)()(.+)/
   field :country, "Tonga"
   field :a2, "TO"
   field :a3, "TON"
-  match :regex
 end

--- a/lib/phone/tr.ex
+++ b/lib/phone/tr.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TR do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(90)(.{3})(.{7})/
   field :country, "Turkey"
   field :a2, "TR"
   field :a3, "TUR"
-  match :regex
 end

--- a/lib/phone/tr.ex
+++ b/lib/phone/tr.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TR do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "90"
   field :regex, ~r/^(90)(.{3})(.{7})/
   field :country, "Turkey"
   field :a2, "TR"

--- a/lib/phone/tv.ex
+++ b/lib/phone/tv.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TV do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "688"
   field :regex, ~r/^(688)()(.{5,6})/
   field :country, "Tuvalu"
   field :a2, "TV"

--- a/lib/phone/tv.ex
+++ b/lib/phone/tv.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TV do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(688)()(.{5,6})/
   field :country, "Tuvalu"
   field :a2, "TV"
   field :a3, "TUV"
-  match :regex
 end

--- a/lib/phone/tw.ex
+++ b/lib/phone/tw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(886)()(.+)/
   field :country, "Taiwan"
   field :a2, "TW"
   field :a3, "TWN"
-  match :regex
 end

--- a/lib/phone/tw.ex
+++ b/lib/phone/tw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "886"
   field :regex, ~r/^(886)()(.+)/
   field :country, "Taiwan"
   field :a2, "TW"

--- a/lib/phone/tz.ex
+++ b/lib/phone/tz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.TZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "255"
   field :regex, ~r/^(255)()(.{9})/
   field :country, "Tanzania"
   field :a2, "TZ"

--- a/lib/phone/tz.ex
+++ b/lib/phone/tz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.TZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(255)()(.{9})/
   field :country, "Tanzania"
   field :a2, "TZ"
   field :a3, "TZA"
-  match :regex
 end

--- a/lib/phone/ua.ex
+++ b/lib/phone/ua.ex
@@ -1,8 +1,7 @@
 defmodule Phone.UA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(380)()(.{9})/
   field :country, "Ukraine"
   field :a2, "UA"
   field :a3, "UKR"
-  match :regex
 end

--- a/lib/phone/ua.ex
+++ b/lib/phone/ua.ex
@@ -1,5 +1,6 @@
 defmodule Phone.UA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "380"
   field :regex, ~r/^(380)()(.{9})/
   field :country, "Ukraine"
   field :a2, "UA"

--- a/lib/phone/ug.ex
+++ b/lib/phone/ug.ex
@@ -1,5 +1,6 @@
 defmodule Phone.UG do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "256"
   field :regex, ~r/^(256)()(.{8})/
   field :country, "Uganda"
   field :a2, "UG"

--- a/lib/phone/ug.ex
+++ b/lib/phone/ug.ex
@@ -1,8 +1,7 @@
 defmodule Phone.UG do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(256)()(.{8})/
   field :country, "Uganda"
   field :a2, "UG"
   field :a3, "UGA"
-  match :regex
 end

--- a/lib/phone/uy.ex
+++ b/lib/phone/uy.ex
@@ -1,5 +1,6 @@
 defmodule Phone.UY do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "598"
   field :regex, ~r/^(598)()(.+)/
   field :country, "Uruguay"
   field :a2, "UY"

--- a/lib/phone/uy.ex
+++ b/lib/phone/uy.ex
@@ -1,8 +1,7 @@
 defmodule Phone.UY do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(598)()(.+)/
   field :country, "Uruguay"
   field :a2, "UY"
   field :a3, "URY"
-  match :regex
 end

--- a/lib/phone/uz.ex
+++ b/lib/phone/uz.ex
@@ -1,8 +1,7 @@
 defmodule Phone.UZ do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(998)()(.{9})/
   field :country, "Uzbekistan"
   field :a2, "UZ"
   field :a3, "UZB"
-  match :regex
 end

--- a/lib/phone/uz.ex
+++ b/lib/phone/uz.ex
@@ -1,5 +1,6 @@
 defmodule Phone.UZ do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "998"
   field :regex, ~r/^(998)()(.{9})/
   field :country, "Uzbekistan"
   field :a2, "UZ"

--- a/lib/phone/ve.ex
+++ b/lib/phone/ve.ex
@@ -1,5 +1,6 @@
 defmodule Phone.VE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "58"
   field :regex, ~r/^(58)(.{3})(.{7})/
   field :country, "Venezuela"
   field :a2, "VE"

--- a/lib/phone/ve.ex
+++ b/lib/phone/ve.ex
@@ -1,8 +1,7 @@
 defmodule Phone.VE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(58)(.{3})(.{7})/
   field :country, "Venezuela"
   field :a2, "VE"
   field :a3, "VEN"
-  match :regex
 end

--- a/lib/phone/vn.ex
+++ b/lib/phone/vn.ex
@@ -1,8 +1,7 @@
 defmodule Phone.VN do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(84)()(.+)/
   field :country, "Vietnam"
   field :a2, "VN"
   field :a3, "VNM"
-  match :regex
 end

--- a/lib/phone/vn.ex
+++ b/lib/phone/vn.ex
@@ -1,5 +1,6 @@
 defmodule Phone.VN do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "84"
   field :regex, ~r/^(84)()(.+)/
   field :country, "Vietnam"
   field :a2, "VN"

--- a/lib/phone/vu.ex
+++ b/lib/phone/vu.ex
@@ -1,5 +1,6 @@
 defmodule Phone.VU do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "678"
   field :regex, ~r/^(678)()(.{5})/
   field :country, "Vanuatu"
   field :a2, "VU"

--- a/lib/phone/vu.ex
+++ b/lib/phone/vu.ex
@@ -1,8 +1,7 @@
 defmodule Phone.VU do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(678)()(.{5})/
   field :country, "Vanuatu"
   field :a2, "VU"
   field :a3, "VUT"
-  match :regex
 end

--- a/lib/phone/wf.ex
+++ b/lib/phone/wf.ex
@@ -1,8 +1,7 @@
 defmodule Phone.WF do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(681)()(.{6})/
   field :country, "Wallis and Futuna"
   field :a2, "WF"
   field :a3, "WLF"
-  match :regex
 end

--- a/lib/phone/wf.ex
+++ b/lib/phone/wf.ex
@@ -1,5 +1,6 @@
 defmodule Phone.WF do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "681"
   field :regex, ~r/^(681)()(.{6})/
   field :country, "Wallis and Futuna"
   field :a2, "WF"

--- a/lib/phone/ws.ex
+++ b/lib/phone/ws.ex
@@ -1,8 +1,7 @@
 defmodule Phone.WS do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(685)()(.{6,7})/
   field :country, "Samoa"
   field :a2, "WS"
   field :a3, "WSM"
-  match :regex
 end

--- a/lib/phone/ws.ex
+++ b/lib/phone/ws.ex
@@ -1,5 +1,6 @@
 defmodule Phone.WS do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "685"
   field :regex, ~r/^(685)()(.{6,7})/
   field :country, "Samoa"
   field :a2, "WS"

--- a/lib/phone/ye.ex
+++ b/lib/phone/ye.ex
@@ -1,8 +1,7 @@
 defmodule Phone.YE do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(967)()(.+)/
   field :country, "Yemen"
   field :a2, "YE"
   field :a3, "YEM"
-  match :regex
 end

--- a/lib/phone/ye.ex
+++ b/lib/phone/ye.ex
@@ -1,5 +1,6 @@
 defmodule Phone.YE do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "967"
   field :regex, ~r/^(967)()(.+)/
   field :country, "Yemen"
   field :a2, "YE"

--- a/lib/phone/za.ex
+++ b/lib/phone/za.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ZA do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "27"
   field :regex, ~r/^(27)()(.{10})/
   field :country, "South Africa"
   field :a2, "ZA"

--- a/lib/phone/za.ex
+++ b/lib/phone/za.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ZA do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(27)()(.{10})/
   field :country, "South Africa"
   field :a2, "ZA"
   field :a3, "ZAF"
-  match :regex
 end

--- a/lib/phone/zm.ex
+++ b/lib/phone/zm.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ZM do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(260)()(.{7})/
   field :country, "Zambia"
   field :a2, "ZM"
   field :a3, "ZMB"
-  match :regex
 end

--- a/lib/phone/zm.ex
+++ b/lib/phone/zm.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ZM do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "260"
   field :regex, ~r/^(260)()(.{7})/
   field :country, "Zambia"
   field :a2, "ZM"

--- a/lib/phone/zw.ex
+++ b/lib/phone/zw.ex
@@ -1,8 +1,7 @@
 defmodule Phone.ZW do
-  use Helper.Country
+  use Helper.Country, match: :regex
   field :regex, ~r/^(263)()(.+)/
   field :country, "Zimbabwe"
   field :a2, "ZW"
   field :a3, "ZWE"
-  match :regex
 end

--- a/lib/phone/zw.ex
+++ b/lib/phone/zw.ex
@@ -1,5 +1,6 @@
 defmodule Phone.ZW do
-  use Helper.Country, match: :regex
+  use Helper.Country, match: :regex,
+    number_prefix: "263"
   field :regex, ~r/^(263)()(.+)/
   field :country, "Zimbabwe"
   field :a2, "ZW"

--- a/mix.exs
+++ b/mix.exs
@@ -59,6 +59,7 @@ defmodule Phonex.Mixfile do
       {:credo, "0.5.2", only: :dev},
       {:earmark, "1.0.3", only: :dev},
       {:ex_doc, "0.14.3", only: :dev},
+      {:benchfella, "0.3.3", only: :dev},
       {:inch_ex, "0.5.5", only: :docs}
     ]
   end


### PR DESCRIPTION
I think we can achieve a lot of performance gains in this library by using pattern matching to quickly narrow down the list of possible phone number parsers and then using regular expressions to extract the necessary data and parse the phone number. I tried the following benchmark earlier today to compare pattern matching vs regular expressions and found there's a huge speed difference.

```elixir
defmodule PhoneBench do
  use Benchfella

  @andorra_phone_number "376123456"

  def phone_number_matches?("376"<>_), do: true
  def phone_number_matches?(_), do: false

  bench "pattern match with prefix" do
    true = phone_number_matches?(@andorra_phone_number)
  end

  bench "match with regex" do
    true = Regex.match?(~r/^(376)()(.{6})/, @andorra_phone_number)
  end
end
```

```
## PhoneBench
benchmark name                              iterations   average time
pattern match with prefix                    100000000   0.04 µs/op
match with regex                               1000000   1.24 µs/op
```

That makes me think if we can leverage elixir's pattern matching, we have a tone of room for performance improvements.

This is my first try at using pattern matching, and I think there are a lot more gains we can make. I changed how you set the the match type for each country module (to eventually allow for overriding functions) and added a `number_prefix` option that helps with the pattern matching in the generated `match?` function. I would recommend looking at the commits one at a time and letting me know what you think.
Here's the before and after performance metrics.

```
Before

## PhoneBench
benchmark name                              iterations   average time
Phone.parse/1 with an Andorra phone number        5000   673.05 µs/op
Phone.parse/1 with a Zimbabwe phone number        5000   691.99 µs/op
Phone.parse/1 with an NANP phone number           1000   1047.04 µs/op

With these changes

## PhoneBench
benchmark name                              iterations   average time
Phone.parse/1 with an Andorra phone number       10000   294.79 µs/op
Phone.parse/1 with a Zimbabwe phone number       10000   298.49 µs/op
Phone.parse/1 with an NANP phone number           5000   713.80 µs/op

Difference

## PhoneBench
Phone.parse/1 with a Zimbabwe phone number    0.43
Phone.parse/1 with an Andorra phone number    0.44
Phone.parse/1 with an NANP phone number       0.68
```

I'm curious to see if we could have even bigger gains if we could move the phone number parsing into one giant (generated) parse function with one definition for each prefix. I'm not sure how we'd do it, but it would be interesting to see how fast we can make this library.