### PR TITLE
Allow to use 2 digits for UAE area code

### DIFF
--- a/lib/phone/ae.ex
+++ b/lib/phone/ae.ex
@@ -3,7 +3,7 @@ defmodule Phone.AE do
 
   use Helper.Country
 
-  def regex, do: ~r/^(971)(.)(.{7})/
+  def regex, do: ~r/^(971)(.{1,2})(.{7})/
   def country, do: "United Arab Emirates"
   def a2, do: "AE"
   def a3, do: "ARE"


### PR DESCRIPTION
Hi, @fcevado 
Thank you for such amazing and helpful library!

I want to propose to allow to use 2 digits for the UAE area code cause it was changed recently.

**Tested environment**:
* Erlang/OTP 21.0
* Elixir 1.6.6

**Changes**:
* UAE area code can contain two digits now