### PR TITLE
✨ solve south africa parsing issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 erl_crash.dump
 *.ez
 mix.lock
+*.iml
+.idea/

--- a/lib/phone/za.ex
+++ b/lib/phone/za.ex
@@ -3,7 +3,7 @@ defmodule Phone.ZA do
 
   use Helper.Country
 
-  def regex, do: ~r/^(27)()(.{10})/
+  def regex, do: ~r/^(27)()(.{9})/
   def country, do: "South Africa"
   def a2, do: "ZA"
   def a3, do: "ZAF"


### PR DESCRIPTION
according to https://en.wikipedia.org/wiki/Telephone_numbers_in_South_Africa, if we are following international access code standard, `'0' is omitted`, so only 9 digits after the country code 27