### PR TITLE
Increase Italian digits number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## v0.4.5
+
+* Fix Italy regex to consider 3 minimum digits and max 12
+
 ## v0.4.4:
   * Fix Australia regex
   * Fix Ireland regex

--- a/lib/phone/it.ex
+++ b/lib/phone/it.ex
@@ -3,7 +3,7 @@ defmodule Phone.IT do
 
   use Helper.Country
 
-  def regex, do: ~r/^(39)()(.{9,10})/
+  def regex, do: ~r/^(39)()(.{3,12})/
   def country, do: "Italy"
   def a2, do: "IT"
   def a3, do: "ITA"


### PR DESCRIPTION
Italy doesn't have a specific length, they may vary between 3 up to
12 digits.

References:

- https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#Italy
- https://en.wikipedia.org/wiki/Telephone_numbers_in_Italy#Number_formats