### PR TITLE
Fix max length for German numbers to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.6
+
+* Fix max length for German numbers to 11
 
 ## v0.4.5
 

--- a/lib/phone/de.ex
+++ b/lib/phone/de.ex
@@ -3,7 +3,7 @@ defmodule Phone.DE do
 
   use Helper.Country
 
-  def regex, do: ~r/^(49)()(.{8})/
+  def regex, do: ~r/^(49)()(.{8,11})/
   def country, do: "Germany"
   def a2, do: "DE"
   def a3, do: "DEU"


### PR DESCRIPTION
Reference:

"A new numbering plan was introduced on 3 May 2010. Since then new landline
phone numbers have a standard length of 11 digits, which includes the
area code but omits the trunk prefix of 0. Area codes remain as they
are and are still variable in length. Exceptions to the 11 digit rule
are the four cities of Berlin, Frankfurt, Hamburg and Munich, which are
the only cities with two digit area codes and require only 10 digit
numbers so as not to exceed the maximum length of 8 digits for a
subscriber number."

https://en.wikipedia.org/wiki/Telephone_numbers_in_Germany