### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,9 +1,9 @@
+# Used by "mix format"
 [
   inputs: [
-    "mix.exs",
-    "{config,lib,priv,test,bench}/**/*.{ex,exs}",
+    "{mix,.formatter}.exs",
+    "{config,lib,test,bench}/**/*.{ex,exs}"
   ],
-
   locals_without_parens: [
     # Formatter tests
     assert_format: 2,

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,32 @@
-/_build
-/bench/snapshots
-/cover
-/doc
-/docs
-/deps
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+phone-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/
+
+# Misc.
+/bench/snapshots/
+.idea/
 mix.lock
 *.iml
-.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,50 @@
 # Changelog
 
-## v0.5.2
+## v0.5.2 - 2020-12-29
 
-  * Update regex for Jamaica to support new region code. 
+  * Update regex for Jamaica to support new region code.
   * Fix typo on Saint Vincent and the Grenadines country name.
 
-## v0.5.1
+## v0.5.1 - 2020-05-06
 
-  * Update regex for Singapore to support 10 digits number. 
+  * Update regex for Singapore to support 10 digits number.
 
-## v0.5.0
+## v0.5.0 - 2020-04-29
 
-  * Add support to region codes for Spain. 
+  * Add support to region codes for Spain.
 
-## v0.4.11
+## v0.4.11 - 2020-04-27
 
   * Update regex for Belgium.
 
-## v0.4.10
+## v0.4.10 - 2020-03-31
 
   * Add new area codes for US, California.
   * Update regex for Netherlands
 
-## v0.4.9
+## v0.4.9 - 2020-03-12
 
   * Add Vancouver missing area code
 
-## v0.4.8
+## v0.4.8 - 2020-01-20
 
   * Add brazilian toll free numbers
 
-## v0.4.6
+## v0.4.6 - 2019-07-02
 
   * Fix max length for German numbers to 11
 
-## v0.4.5
+## v0.4.5 - 2019-02-21
 
   * Fix Italy regex to consider 3 minimum digits and max 12
 
-## v0.4.4:
+## v0.4.4 - 2019-01-16
+
   * Fix Australia regex
   * Fix Ireland regex
 
-## v0.4.4:
+## v0.4.4 - 2019-01-16
+
   * Fix United Arab Emirates parsing
   * Fix Germany parsing
   * Fix Brazil parsing
@@ -50,67 +52,84 @@
   * Fix Pakistan parsing
   * Fix Monaco parsing
   * Fix Ireland parsing
-  
-## v0.4.3:
+
+## v0.4.3 - 2018-03-24
+
   * Add Idaho, New York, Pennsylvania, Texas, Washington missing area codes.
   * Fix typo on NANP Toll Free Number module.
 
-## v0.4.2:
+## v0.4.2 - 2017-09-05
+
   * Correct parsing for Angola numbers
 
-## v0.4.1:
+## v0.4.1 - 2017-06-16
+
   * Add 833 toll free number to NANP
 
-## v0.4.0:
+## v0.4.0 - 2017-04-02
+
   * Updates `Helper.Countries` and `Helper.Area` behavior
   * Several changes to improve performance.
   * Include `valid?/1`.
   * Remove warning from v0.3
 
-## v0.3.10:
+## v0.3.10 - 2017-01-15
+
   * Correct number validation for Norway.
   * Correct Ireland area codes validation.
 
-## v0.3.9:
+## v0.3.9 - 2016-11-11
+
   * Add and correct various area codes for NANP.
   * Better test coverage for NANP numbers.
 
-## v0.3.8:
+## v0.3.8 - 2016-11-09
+
   * Add 424 area code for California.
   * Add 475 area code for Connecticut.
 
-## v0.3.7:
+## v0.3.7 - 2016-10-28
+
   * Correct area code for Ontario - US.
 
-## v0.3.6:
+## v0.3.6 - 2016-08-26
+
   * Correct number validation to Italy.
 
-## v0.3.5:
+## v0.3.5 - 2016-08-14
+
   * Correct number validation to Bosnia and Herzegovina.
 
-## v0.3.4:
+## v0.3.4 - 2016-08-03
+
   * Correct number validation to Estonia.
 
-## v0.3.3:
+## v0.3.3 - 2016-08-02
+
   * Correct number validation to São Paulo - BR.
 
-## v0.3.2:
+## v0.3.2 - 2016-07-24
+
   * Area codes for Brazil.
   * Updated all regular expressions for NANP, to enforce end of line.
 
-## v0.3.1:
+## v0.3.1 - 2016-07-21
+
   * Issues with Croatia numbers corrected.
 
-## v0.3.0:
+## v0.3.0 - 2016-07-10
+
   * Changed `parse/2` parameters order for a better use on pipes.
   * Added functions `parse!/1` and `parse!/2` for a direct return, and raises on error.
 
-## v0.2.1:
+## v0.2.1 - 2016-06-14
+
   * Correct area codes for Colorado - US.
 
-## v0.2.0:
+## v0.2.0 - 2016-06-05
+
   * Add `parse/2` to `Phone` module, so can parse phone numbers without international code but with atom identifying the country.
 
-## v0.1.0:
-  * First public release
+## v0.1.0 - 2016-04-21
 
+  * First public release

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 Flávio Moreira Vieira
+Copyright (c) 2016 Flávio Moreira Vieira
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Phone
+
 [![Build Status](https://travis-ci.org/fcevado/phone.svg?branch=master)](https://travis-ci.org/fcevado/phone)
 [![Coverage Status](https://coveralls.io/repos/github/fcevado/phone/badge.svg?branch=master)](https://coveralls.io/github/fcevado/phone?branch=master)
-||
-[![SourceLevel](https://app.sourcelevel.io/github/fcevado/-/phone.svg)](https://app.sourcelevel.io/github/fcevado/-/phone)
-[![GitHub issues](https://img.shields.io/github/issues/fcevado/phone.svg)](https://github.com/fcevado/phone/issues)
-[![Inline docs](http://inch-ci.org/github/fcevado/phone.svg?branch=master)](http://inch-ci.org/github/fcevado/phone)
-||
-[![Phone version](https://img.shields.io/hexpm/v/phone.svg)](https://hex.pm/packages/phone)
-[![Hex.pm](https://img.shields.io/hexpm/dt/phone.svg)](https://hex.pm/packages/phone)
-[![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/fcevado/phone/master/LICENSE)
+[![Module Version](https://img.shields.io/hexpm/v/phone.svg)](https://hex.pm/packages/phone)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/phone/)
+[![Total Download](https://img.shields.io/hexpm/dt/phone.svg)](https://hex.pm/packages/phone)
+[![License](https://img.shields.io/hexpm/l/phone.svg)](https://github.com/fcevado/phone/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/fcevado/phone.svg)](https://github.com/fcevado/phone/commits/master)
 
 Phone number parser for telephone numbers in international standard or missing international country code, for [Elixir](http://elixir-lang.org).
 
@@ -18,8 +16,9 @@ Note on version `0.4.0` onward: `Phone` was rebuild to increase performance, tha
 * [Hex](https://hex.pm/packages/phone)
 
 ## About
-What is, what isnt and what will be about Phone:
-  1. It isnt:
+
+What is, what isn't and what will be about Phone:
+  1. It isn't:
     * Intended to work as libphonenumber.
     * Prepared to format numbers.
     * Necessary any information about the number if in international standard.
@@ -58,6 +57,7 @@ What is, what isnt and what will be about Phone:
         ```
 
 ## Area Codes
+
   Countries that already has area code info:
   * United States.
   * Canada.
@@ -65,25 +65,34 @@ What is, what isnt and what will be about Phone:
   * Spain.
 
 ## Vocabulary
+
   * a2: Alpha-2, two letters code for country names.
   * a3: Alpha-3, three letters code for country names.
   * NANP: North American Numbering Plan, numbering plan for countries with international code number 1.
   * Numbering Plan: The rules and specifications of how telephone numbers works in a given country.
 
 ## Installation
-Add to your depencies like any other hex package.
+
+Add to your dependencies like any other hex package:
 
 ```elixir
 defp deps do
-  [{:phone, "0.5.0"}]
+  [
+    {:phone, "0.5.0"}
+  ]
 end
 ```
 
-## [Contributing](./CONTRIBUTING.md)
-
-## [Changelog](./CHANGELOG.md)
-
-## [Code of Conduct](./CODE_OF_CONDUCT.md)
-
 ## License
-Phone is under Apache v2.0 license. Check the [LICENSE](./LICENSE) file for more details.
+
+Copyright (c) 2016 Flávio Moreira Vieira
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/lib/phone.ex
+++ b/lib/phone.ex
@@ -122,7 +122,7 @@ defmodule Phone do
   country_parser()
 
   @doc """
-  Returns `true` if the number can be parsed, otherwhise returns `false`.
+  Returns `true` if the number can be parsed, otherwise returns `false`.
 
   ```
   iex> Phone.valid?("555132345678")

--- a/mix.exs
+++ b/mix.exs
@@ -1,37 +1,58 @@
 defmodule Phone.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/fcevado/phone"
+  @version "0.5.2"
+
   def project do
     [
       app: :phone,
-      version: "0.5.2",
+      version: @version,
       elixir: ">= 1.1.0",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      description: description(),
       package: package(),
-      source_url: "https://github.com/fcevado/phone",
-      deps: deps()
+      deps: deps(),
+      docs: docs()
     ] ++ coverage()
-  end
-
-  defp package do
-    [
-      files: files(),
-      maintainers: ["Flávio M.V."],
-      licenses: ["Apache 2.0"],
-      links: links()
-    ]
-  end
-
-  defp description do
-    """
-    Get useful info from telephone numbers.
-    """
   end
 
   def application do
     [applications: []]
+  end
+
+  defp package do
+    [
+      description: """
+      Phone number parser for telephone numbers in international standard or
+      missing international country code.
+      """,
+      maintainers: ["Flávio M.V."],
+      licenses: ["Apache-2.0"],
+      links: %{
+        "Changelog" => "https://hexdocs.pm/phone/changelog.html",
+        "GitHub" => @source_url
+      }
+    ]
+  end
+
+  defp deps do
+    [
+      {:excoveralls, "0.13.4", only: :test, runtime: false},
+      {:credo, "1.5.4", only: :dev, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:benchfella, "0.3.5", only: :dev},
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["CHANGELOG.md", "README.md"],
+      main: "readme",
+      formatters: ["html"],
+      api_reference: false,
+      skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
+    ]
   end
 
   defp coverage do
@@ -43,30 +64,6 @@ defmodule Phone.Mixfile do
         "coveralls.post": :test,
         "coveralls.html": :test
       ]
-    ]
-  end
-
-  defp files do
-    [
-      "mix.exs",
-      "lib"
-    ]
-  end
-
-  defp links do
-    %{
-      "Github" => "https://github.com/fcevado/phone"
-    }
-  end
-
-  defp deps do
-    [
-      {:excoveralls, "0.13.4", only: :test},
-      {:credo, "1.5.4", only: :dev},
-      {:earmark, "1.4.13", only: :dev},
-      {:ex_doc, "0.23.0", only: :dev},
-      {:benchfella, "0.3.5", only: :dev},
-      {:inch_ex, "2.0.0", only: :docs}
     ]
   end
 end


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main source doc for this Elixir library which
leverage on ExDoc features.

List of changes:
* Fix typos
* Set readme as main html doc
* Update gitignore
* Update formatter config
* Add missing dates for changelog
* Add changelog to html doc
* Set doc output to html
* Fix spdx license id
* Refactor project config
* Update license section
* Badges and more badges!
* Sync description

Screenshot:
![Screenshot-20210316230002-2636x1412](https://user-images.githubusercontent.com/134518/111336437-34045f80-86b0-11eb-97f6-fa605bb8c06b.png)
