### PR TITLE
Support +74 for Russia

### DIFF
--- a/lib/phone/ru.ex
+++ b/lib/phone/ru.ex
@@ -8,5 +8,5 @@ defmodule Phone.RU do
   def a2, do: "RU"
   def a3, do: "RUS"
 
-  matcher(:regex, ["73", "75", "78", "79"])
+  matcher(:regex, ["73", "74", "75", "78", "79"])
 end


### PR DESCRIPTION
Moscow numbers(+7 495) are not recognized

It looks like +74 is simply missing from the codes list because the regex looks correct