### PR TITLE
Added zone codes for Brazil

### DIFF
--- a/lib/phone/br/pe.ex
+++ b/lib/phone/br/pe.ex
@@ -8,5 +8,5 @@ defmodule Phone.BR.PE do
   def area_type, do: "state"
   def area_abbreviation, do: "PE"
 
-  matcher(["5581", "5587"])
+  matcher(["5581", "5589"])
 end

--- a/lib/phone/br/pi.ex
+++ b/lib/phone/br/pi.ex
@@ -8,5 +8,5 @@ defmodule Phone.BR.PI do
   def area_type, do: "state"
   def area_abbreviation, do: "PI"
 
-  matcher(["5586", "5589"])
+  matcher(["5586", "5587"])
 end

--- a/lib/phone/br/pr.ex
+++ b/lib/phone/br/pr.ex
@@ -8,5 +8,5 @@ defmodule Phone.BR.PR do
   def area_type, do: "state"
   def area_abbreviation, do: "PR"
 
-  matcher(["5541", "5546"])
+  matcher(["5541", "5542", "5543", "5544", "5545", "5546"])
 end

--- a/lib/phone/br/rs.ex
+++ b/lib/phone/br/rs.ex
@@ -8,5 +8,5 @@ defmodule Phone.BR.RS do
   def area_type, do: "state"
   def area_abbreviation, do: "RS"
 
-  matcher(["5551", "5553", "5554", "5555"])
+  matcher(["5551", "5552", "5553", "5554", "5555"])
 end


### PR DESCRIPTION
Adding support for the following area codes for Brazil:
- Parana (5542,5543,5544,5545)
- Pernambuco (5589)
- Piauí (5587)
- Rio Grande do Sul (5552)