### PR TITLE
support +61 for Australia

### DIFF
--- a/lib/helpers/parser.ex
+++ b/lib/helpers/parser.ex
@@ -81,6 +81,7 @@ defmodule Helper.Parser do
       parser(:ao, "244")
       parser(:ar, "54")
       parser(:at, "43")
+      parser(:au, "61")
       parser(:aw, "297")
       parser(:az, "994")
 


### PR DESCRIPTION
support for Australia was found missing from the parser file.